### PR TITLE
Fix Firestore rules syntax for cloze states

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,7 +43,7 @@ service cloud.firestore {
     }
 
     function isValidClozeStates(mapValue) {
-      return mapValue is map && mapValue.values().all(entry => isValidClozeState(entry));
+      return mapValue is map && mapValue.values().all(entry, isValidClozeState(entry));
     }
 
     function isValidPage(data) {


### PR DESCRIPTION
## Summary
- replace the arrow-style predicate in `isValidClozeStates` with the supported `all(entry, ...)` form
- ensure the Firestore rules file parses correctly by removing the syntax error on the `clozeStates` validation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ef3ca0548333ae40ef8afa93ae9c