### PR TITLE
Fix Firestore rules validation for cloze states

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -43,7 +43,8 @@ service cloud.firestore {
     }
 
     function isValidClozeStates(mapValue) {
-      return mapValue is map && mapValue.values().all(entry, isValidClozeState(entry));
+      return mapValue is map &&
+             mapValue.values().where(entry, !isValidClozeState(entry)).size() == 0;
     }
 
     function isValidPage(data) {


### PR DESCRIPTION
## Summary
- replace the unsupported mapValue.values().all usage in the cloze state validation helper
- ensure cloze state maps are validated by filtering invalid entries and checking that none remain

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f1803284833394bbedeea2a30e43