### PR TITLE
Add Firebase Auth pseudo login with secure rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Application web de prise de notes et de révision active avec texte à trous et 
 
 ## Fonctionnalités
 
-- Connexion par pseudo (sans mot de passe) avec conservation automatique de la session.
+- Connexion par pseudo (via Firebase Authentication) avec création automatique du compte.
 - Gestion multi-cours : création, ouverture et suppression de cours.
 - Arborescence chapitres/pages/sous-pages avec ajout, renommage et suppression.
 - Éditeur riche simple (gras, italique, listes, titres, insertion d’images) et transformation de portions de texte en trous à réviser.
@@ -14,8 +14,10 @@ Application web de prise de notes et de révision active avec texte à trous et 
 ## Déploiement
 
 1. Hébergez les fichiers statiques (`index.html`, `styles.css`, `app.js`) sur GitHub Pages ou tout hébergeur statique.
-2. Configurez votre projet Firebase Firestore avec des règles adaptées à un usage sans authentification (ou ajoutez votre propre stratégie d’authentification).
-3. Mettez à jour la configuration Firebase dans `app.js` si nécessaire.
+2. Activez l’authentification **Email/Mot de passe** dans Firebase Authentication. L’application génère une adresse du type `<pseudo>@pseudo.apprentissage` et un mot de passe dérivé pour chaque utilisateur.
+3. Mettez à jour la configuration Firebase et, si besoin, les constantes `AUTH_EMAIL_DOMAIN` / `AUTH_PASSWORD_SUFFIX` dans `app.js` ainsi que la règle `isOwner` de `firestore.rules` si vous changez le domaine.
+
+> Les pseudos saisis sont normalisés (minuscules, accents supprimés et caractères non autorisés remplacés par `-`) afin de constituer un identifiant valide pour Firebase Authentication.
 
 ## Développement local
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,7 +7,8 @@ service cloud.firestore {
     }
 
     function isOwner(userId) {
-      return isSignedIn() && request.auth.uid == userId;
+      // Les comptes utilisent une adresse générée de la forme <pseudo>@pseudo.apprentissage (cf. app.js).
+      return isSignedIn() && request.auth.token.email == userId + '@pseudo.apprentissage';
     }
 
     function nonEmptyString(value, maxLen) {


### PR DESCRIPTION
## Summary
- integrate Firebase Authentication email/password flow behind the pseudo login form and normalise pseudos for consistent IDs
- update Firestore rules to match the generated authentication email domain and keep data validation
- document the new authentication requirements and pseudo normalisation in the README

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d3fa09078c8333bcc8501d8fac1648