### PR TITLE
Handle Firebase configuration error and add favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Application web de prise de notes et de révision active avec texte à trous et 
 
 > Les pseudos saisis sont normalisés (minuscules, accents supprimés et caractères non autorisés remplacés par `-`) afin de constituer un identifiant valide pour Firebase Authentication.
 
+## Dépannage
+
+- **Erreur `FirebaseError: Firebase: Error (auth/configuration-not-found)` lors de la connexion** : la méthode de connexion *Email/Mot de passe* n’est pas activée pour votre projet Firebase. Rendez-vous dans la console Firebase > *Authentication* > *Méthode de connexion* et activez ce fournisseur, puis réessayez.
+
 ## Développement local
 
 Servez les fichiers statiques via un serveur HTTP (par exemple `npx serve`) afin de bénéficier des modules ES.

--- a/app.js
+++ b/app.js
@@ -242,6 +242,11 @@ function handleLoginSubmit(event) {
         case "auth/missing-email":
           message = "Pseudo invalide. Vérifiez les caractères utilisés.";
           break;
+        case "auth/configuration-not-found":
+        case "auth/operation-not-allowed":
+          message =
+            "La connexion par e-mail/mot de passe n'est pas configurée pour ce projet Firebase. Activez la méthode 'Email/Mot de passe' dans Firebase Authentication.";
+          break;
         case "auth/too-many-requests":
           message = "Trop de tentatives de connexion. Réessayez plus tard.";
           break;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apprentissage actif</title>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' ry='6' fill='%23204770'/%3E%3Cpath d='M9 23h3l4-6 4 6h3l-5.5-8L23 9h-3l-4 5.8L12 9H9l5.5 8z' fill='%23ffffff'/%3E%3C/svg%3E"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add a helpful message when Firebase returns the auth/configuration-not-found or operation-not-allowed errors during login
- document the troubleshooting step for this authentication error in the README
- embed a small SVG favicon to stop the favicon.ico 404 in browsers

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d3ff6129a48333b1672108b9d364a3