### PR TITLE
Add explicit Firebase configuration setup and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Application web de prise de notes et de révision active avec texte à trous et 
 ## Déploiement
 
 1. Hébergez les fichiers statiques (`index.html`, `styles.css`, `app.js`) sur GitHub Pages ou tout hébergeur statique.
-2. Activez l’authentification **Email/Mot de passe** dans Firebase Authentication. L’application génère une adresse du type `<pseudo>@pseudo.apprentissage` et un mot de passe dérivé pour chaque utilisateur.
-3. Mettez à jour la configuration Firebase et, si besoin, les constantes `AUTH_EMAIL_DOMAIN` / `AUTH_PASSWORD_SUFFIX` dans `app.js` ainsi que la règle `isOwner` de `firestore.rules` si vous changez le domaine.
+2. Dans la console Firebase, créez une application Web puis copiez les identifiants fournis (API key, Auth domain, Project ID…). Remplacez les valeurs du fichier `firebase-config.js` par celles de votre projet.
+3. Activez l’authentification **Email/Mot de passe** dans Firebase Authentication. L’application génère une adresse du type `<pseudo>@pseudo.apprentissage` et un mot de passe dérivé pour chaque utilisateur.
+4. Si besoin, ajustez les constantes `AUTH_EMAIL_DOMAIN` / `AUTH_PASSWORD_SUFFIX` dans `app.js` ainsi que la règle `isOwner` de `firestore.rules` si vous changez le domaine.
 
 > Les pseudos saisis sont normalisés (minuscules, accents supprimés et caractères non autorisés remplacés par `-`) afin de constituer un identifiant valide pour Firebase Authentication.
 
 ## Dépannage
 
-- **Erreur `FirebaseError: Firebase: Error (auth/configuration-not-found)` lors de la connexion** : la méthode de connexion *Email/Mot de passe* n’est pas activée pour votre projet Firebase. Rendez-vous dans la console Firebase > *Authentication* > *Méthode de connexion* et activez ce fournisseur, puis réessayez.
+- **Erreur `FirebaseError: Firebase: Error (auth/configuration-not-found)` lors de la connexion** : soit l’application pointe encore vers la configuration d’exemple (vérifiez que toutes les valeurs du fichier `firebase-config.js` ont été remplacées par celles de votre projet), soit la méthode de connexion *Email/Mot de passe* n’est pas activée dans la console Firebase (*Authentication* > *Méthode de connexion*).
 
 ## Développement local
 

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,0 +1,11 @@
+// Remplacez les valeurs ci-dessous par la configuration Web de votre projet Firebase.
+// Vous trouverez ces informations dans la console Firebase > Paramètres du projet > Vos applications.
+export const firebaseConfig = {
+  apiKey: "__REPLACE_WITH_YOUR_FIREBASE_API_KEY__",
+  authDomain: "__REPLACE_WITH_YOUR_FIREBASE_AUTH_DOMAIN__",
+  projectId: "__REPLACE_WITH_YOUR_FIREBASE_PROJECT_ID__",
+  storageBucket: "__REPLACE_WITH_YOUR_FIREBASE_STORAGE_BUCKET__",
+  messagingSenderId: "__REPLACE_WITH_YOUR_FIREBASE_MESSAGING_SENDER_ID__",
+  appId: "__REPLACE_WITH_YOUR_FIREBASE_APP_ID__",
+  measurementId: "__REPLACE_WITH_YOUR_FIREBASE_MEASUREMENT_ID__"
+};

--- a/styles.css
+++ b/styles.css
@@ -117,6 +117,14 @@ main {
   box-shadow: 0 20px 40px -40px rgba(0, 0, 0, 0.3);
 }
 
+.card.error {
+  border: 1px solid var(--warning);
+}
+
+.card.error h2 {
+  color: var(--warning);
+}
+
 .stack {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- require Firebase credentials to live in a dedicated `firebase-config.js` file and fail fast when placeholders are still present
- show a blocking message in the UI if the Firebase config is missing and make the login error hint mention the config file
- document the setup steps in the README and add styling for the new error card

## Testing
- not run (static frontend project)

------
https://chatgpt.com/codex/tasks/task_e_68d40387260083339053b76f5fe9f155