### PR TITLE
Simplify workspace UI and note structure

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,8 +10,7 @@ import {
   query,
   orderBy,
   updateDoc,
-  getDocs,
-  writeBatch,
+  deleteDoc,
   serverTimestamp
 } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
 import {
@@ -74,7 +73,7 @@ function renderFirebaseConfigError(message) {
 
   const instructions = document.createElement("p");
   instructions.textContent =
-    "Ouvrez le fichier firebase-config.js et remplacez les valeurs par celles fournies dans la console Firebase (section Paramètres du projet > Vos applications).";
+    "Ouvrez le fichier firebase-config.js et remplacez les valeurs par celles fournies dans la console Firebase (Paramètres du projet > Vos applications).";
   card.appendChild(instructions);
 
   loginScreen.appendChild(card);
@@ -96,25 +95,33 @@ function bootstrapApp() {
   const AUTH_EMAIL_DOMAIN = "pseudo.apprentissage";
   const AUTH_PASSWORD_SUFFIX = "#appr";
   const MIN_PSEUDO_LENGTH = 3;
+  const SAVE_DEBOUNCE_MS = 700;
+
+  const relativeTime = new Intl.RelativeTimeFormat("fr", { numeric: "auto" });
+  const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
+    day: "2-digit",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
 
   const state = {
     pseudo: null,
     displayName: null,
     pendingDisplayName: null,
-    coursesUnsubscribe: null,
-    pagesUnsubscribe: null,
-    courses: [],
-    pages: [],
-    currentCourse: null,
-    currentPage: null,
-    currentClozeStates: {},
-    revisionHandlers: new Map()
+    notesUnsubscribe: null,
+    notes: [],
+    currentNoteId: null,
+    currentNote: null,
+    pendingSelectionId: null,
+    pendingSave: null,
+    hasUnsavedChanges: false,
+    lastSavedAt: null
   };
 
   const views = {
     login: document.getElementById("login-screen"),
-    dashboard: document.getElementById("dashboard-screen"),
-    course: document.getElementById("course-screen")
+    workspace: document.getElementById("workspace")
   };
 
   const ui = {
@@ -123,59 +130,35 @@ function bootstrapApp() {
     loginButton: document.querySelector("#login-form button[type='submit']"),
     currentUser: document.getElementById("current-user"),
     logoutBtn: document.getElementById("logout-btn"),
-    newCourseForm: document.getElementById("new-course-form"),
-    newCourseName: document.getElementById("new-course-name"),
-    coursesList: document.getElementById("courses-list"),
-    backToDashboard: document.getElementById("back-to-dashboard"),
-    courseTitle: document.getElementById("course-title"),
-    addRootPage: document.getElementById("add-root-page"),
-    addPageForm: document.getElementById("add-page-form"),
-    pageTitleInput: document.getElementById("page-title-input"),
-    parentSelect: document.getElementById("parent-select"),
-    pagesTree: document.getElementById("pages-tree"),
-    editorTab: document.getElementById("editor-tab"),
-    revisionTab: document.getElementById("revision-tab"),
-    editorView: document.getElementById("editor-view"),
-    revisionView: document.getElementById("revision-view"),
-    pageEmpty: document.getElementById("page-empty"),
-    editor: document.getElementById("editor"),
-    saveButton: document.getElementById("save-page-btn"),
+    addNoteBtn: document.getElementById("add-note-btn"),
+    notesContainer: document.getElementById("notes-container"),
+    noteTitle: document.getElementById("note-title"),
+    noteEditor: document.getElementById("note-editor"),
     saveStatus: document.getElementById("save-status"),
-    insertImageBtn: document.getElementById("insert-image-btn"),
-    createClozeBtn: document.getElementById("create-cloze-btn"),
-    removeClozeBtn: document.getElementById("remove-cloze-btn"),
-    revisionContent: document.getElementById("revision-content"),
-    newIterationBtn: document.getElementById("new-iteration-btn"),
-    toast: document.getElementById("toast")
+    editorWrapper: document.getElementById("editor-wrapper"),
+    emptyState: document.getElementById("empty-note"),
+    toast: document.getElementById("toast"),
+    toolbar: document.querySelector(".editor-toolbar")
   };
 
-  const editorToolbar = document.querySelector(".editor-toolbar");
   ui.logoutBtn.disabled = true;
 
-  function showView(view) {
-    Object.values(views).forEach((section) => section.classList.add("hidden"));
-    Object.values(views).forEach((section) => section.classList.remove("active"));
-    const target = views[view];
-    if (target) {
-      target.classList.remove("hidden");
-      target.classList.add("active");
-    }
+  function showView(name) {
+    Object.entries(views).forEach(([key, section]) => {
+      if (!section) return;
+      section.classList.toggle("active", key === name);
+      section.classList.toggle("hidden", key !== name);
+    });
   }
 
   function showToast(message, type = "info") {
+    if (!ui.toast) return;
     ui.toast.textContent = message;
     ui.toast.dataset.type = type;
     ui.toast.classList.remove("hidden");
     setTimeout(() => {
       ui.toast.classList.add("hidden");
-    }, 2400);
-  }
-
-  function safeId() {
-    if (window.crypto && window.crypto.randomUUID) {
-      return window.crypto.randomUUID();
-    }
-    return `cloze-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+    }, 2600);
   }
 
   function normalizePseudoInput(rawPseudo = "") {
@@ -210,57 +193,360 @@ function bootstrapApp() {
     return email.slice(0, -suffix.length);
   }
 
-  function normalizeClozeStateEntry(entry = {}) {
-    const answer = entry.answer ?? "";
-    const rawScore = Number(entry.score ?? entry.counter ?? 0);
-    const score = Math.max(0, Number.isFinite(rawScore) ? Number(rawScore.toFixed(2)) : 0);
-    const fallbackCounter = Math.max(0, Math.floor(score));
-    const rawCounter = Number(entry.counter ?? fallbackCounter);
-    const counter = Number.isFinite(rawCounter)
-      ? Math.max(0, Math.min(fallbackCounter, Math.floor(rawCounter)))
-      : fallbackCounter;
-    return {
-      answer,
-      counter,
-      score
-    };
-  }
-
-  function normalizeClozeStates(states = {}) {
-    const normalized = {};
-    Object.entries(states).forEach(([key, value]) => {
-      normalized[key] = normalizeClozeStateEntry({ ...value });
+  function sanitizeHtml(html = "") {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    container.querySelectorAll("script, style").forEach((el) => el.remove());
+    container.querySelectorAll("*").forEach((el) => {
+      Array.from(el.attributes).forEach((attr) => {
+        if (attr.name.startsWith("on")) {
+          el.removeAttribute(attr.name);
+        }
+      });
     });
-    return normalized;
+    return container.innerHTML;
   }
 
-  function resetState() {
-    if (state.coursesUnsubscribe) {
-      state.coursesUnsubscribe();
-      state.coursesUnsubscribe = null;
+  function formatRelativeDate(date) {
+    if (!(date instanceof Date)) {
+      return "Jamais enregistré";
     }
-    if (state.pagesUnsubscribe) {
-      state.pagesUnsubscribe();
-      state.pagesUnsubscribe = null;
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const absMs = Math.abs(diffMs);
+    const minutes = Math.round(absMs / 60000);
+    if (minutes < 1) {
+      return "À l'instant";
     }
-    state.pseudo = null;
-    state.displayName = null;
-    state.courses = [];
-    state.pages = [];
-    state.currentCourse = null;
-    state.currentPage = null;
-    state.currentClozeStates = {};
-    state.revisionHandlers.clear();
-    ui.coursesList.innerHTML = "";
-    ui.pagesTree.innerHTML = "";
-    ui.editor.innerHTML = "";
-    ui.revisionContent.innerHTML = "";
-    ui.courseTitle.textContent = "";
-    ui.saveStatus.textContent = "";
-    ui.currentUser.textContent = "";
-    togglePagePanels(false);
-    ui.pageEmpty.classList.remove("hidden");
-    ui.logoutBtn.disabled = true;
+    if (minutes < 60) {
+      const value = diffMs < 0 ? -minutes : minutes;
+      return relativeTime.format(value, "minute");
+    }
+    const hours = Math.round(absMs / 3600000);
+    if (hours < 24) {
+      const value = diffMs < 0 ? -hours : hours;
+      return relativeTime.format(value, "hour");
+    }
+    const days = Math.round(absMs / 86400000);
+    const value = diffMs < 0 ? -days : days;
+    return relativeTime.format(value, "day");
+  }
+
+  function updateSaveStatus(stateValue, date = null) {
+    if (!ui.saveStatus) return;
+    ui.saveStatus.dataset.state = stateValue || "";
+    switch (stateValue) {
+      case "dirty":
+        ui.saveStatus.textContent = "Modifications non enregistrées";
+        break;
+      case "saving":
+        ui.saveStatus.textContent = "Enregistrement...";
+        break;
+      case "saved":
+        ui.saveStatus.textContent = date ? `Enregistré le ${dateFormatter.format(date)}` : "Enregistré";
+        break;
+      case "error":
+        ui.saveStatus.textContent = "Erreur d'enregistrement";
+        break;
+      default:
+        ui.saveStatus.textContent = "";
+        break;
+    }
+  }
+
+  function showEmptyEditor() {
+    ui.editorWrapper.classList.add("hidden");
+    ui.emptyState.classList.remove("hidden");
+    ui.noteTitle.value = "";
+    ui.noteEditor.innerHTML = "";
+    updateSaveStatus();
+  }
+
+  function applyCurrentNoteToEditor() {
+    if (!state.currentNote) {
+      showEmptyEditor();
+      return;
+    }
+    ui.emptyState.classList.add("hidden");
+    ui.editorWrapper.classList.remove("hidden");
+    ui.noteTitle.value = state.currentNote.title || "";
+    ui.noteEditor.innerHTML = state.currentNote.contentHtml || "";
+    state.lastSavedAt = state.currentNote.updatedAt instanceof Date ? state.currentNote.updatedAt : null;
+    if (state.hasUnsavedChanges) {
+      updateSaveStatus("dirty");
+    } else {
+      updateSaveStatus(state.lastSavedAt ? "saved" : "", state.lastSavedAt || null);
+    }
+  }
+
+  function updateActiveNoteHighlight() {
+    const items = ui.notesContainer.querySelectorAll(".note-card");
+    items.forEach((item) => {
+      const noteId = item.dataset.noteId;
+      item.classList.toggle("active", noteId === state.currentNoteId);
+    });
+  }
+
+  function renderNotes() {
+    ui.notesContainer.innerHTML = "";
+    if (!state.notes.length) {
+      const empty = document.createElement("p");
+      empty.className = "muted small";
+      empty.textContent = "Aucune fiche pour le moment. Ajoutez-en une pour commencer.";
+      ui.notesContainer.appendChild(empty);
+      return;
+    }
+
+    state.notes.forEach((note) => {
+      const row = document.createElement("div");
+      row.className = "note-row";
+
+      const card = document.createElement("button");
+      card.type = "button";
+      card.className = "note-card";
+      card.dataset.noteId = note.id;
+      card.addEventListener("click", () => {
+        selectNoteById(note.id).catch((error) => {
+          console.error("Impossible d'ouvrir la fiche", error);
+          showToast("Impossible d'ouvrir la fiche", "error");
+        });
+      });
+
+      const title = document.createElement("span");
+      title.className = "note-card-title";
+      title.textContent = note.title && note.title.trim() ? note.title.trim() : "Sans titre";
+      card.appendChild(title);
+
+      const meta = document.createElement("span");
+      meta.className = "note-card-meta";
+      meta.textContent = formatRelativeDate(note.updatedAt);
+      card.appendChild(meta);
+
+      const deleteBtn = document.createElement("button");
+      deleteBtn.type = "button";
+      deleteBtn.className = "icon-button";
+      deleteBtn.title = "Supprimer la fiche";
+      deleteBtn.textContent = "✕";
+      deleteBtn.addEventListener("click", (event) => {
+        event.stopPropagation();
+        deleteNote(note.id).catch((error) => {
+          console.error("Impossible de supprimer la fiche", error);
+          showToast("Impossible de supprimer la fiche", "error");
+        });
+      });
+
+      row.appendChild(card);
+      row.appendChild(deleteBtn);
+      ui.notesContainer.appendChild(row);
+    });
+
+    updateActiveNoteHighlight();
+  }
+
+  function updateNotesFromSnapshot(snapshot) {
+    state.notes = snapshot.docs.map((docSnap) => {
+      const data = docSnap.data() || {};
+      const toDate = (value) => (value && typeof value.toDate === "function" ? value.toDate() : null);
+      return {
+        id: docSnap.id,
+        title: data.title || "",
+        contentHtml: data.contentHtml || "",
+        createdAt: toDate(data.createdAt),
+        updatedAt: toDate(data.updatedAt)
+      };
+    });
+
+    renderNotes();
+    ensureCurrentSelection();
+  }
+
+  function ensureCurrentSelection() {
+    if (state.pendingSelectionId) {
+      const pending = state.notes.find((note) => note.id === state.pendingSelectionId);
+      if (pending) {
+        state.pendingSelectionId = null;
+        openNote(pending, { skipFlush: true });
+      }
+      return;
+    }
+
+    if (state.currentNoteId) {
+      const current = state.notes.find((note) => note.id === state.currentNoteId);
+      if (current) {
+        state.currentNote = { ...current };
+        state.hasUnsavedChanges = false;
+        applyCurrentNoteToEditor();
+        updateActiveNoteHighlight();
+        return;
+      }
+    }
+
+    if (state.notes.length > 0) {
+      openNote(state.notes[0], { skipFlush: true });
+    } else {
+      state.currentNoteId = null;
+      state.currentNote = null;
+      state.hasUnsavedChanges = false;
+      showEmptyEditor();
+      updateActiveNoteHighlight();
+    }
+  }
+
+  async function openNote(note, options = {}) {
+    if (!note) return;
+    const { skipFlush = false } = options;
+    if (!skipFlush) {
+      await flushPendingSave();
+    }
+    state.currentNoteId = note.id;
+    state.currentNote = { ...note };
+    state.hasUnsavedChanges = false;
+    applyCurrentNoteToEditor();
+    updateActiveNoteHighlight();
+    setTimeout(() => ui.noteTitle.focus(), 80);
+  }
+
+  async function selectNoteById(noteId) {
+    if (!noteId) return;
+    if (state.currentNoteId === noteId && state.currentNote) {
+      return;
+    }
+    const target = state.notes.find((note) => note.id === noteId);
+    if (!target) return;
+    await openNote(target);
+  }
+
+  function updateLocalNoteCache(noteId, updates) {
+    state.notes = state.notes.map((note) => (note.id === noteId ? { ...note, ...updates } : note));
+  }
+
+  function handleTitleInput(event) {
+    if (!state.currentNote) return;
+    state.currentNote.title = event.target.value;
+    state.hasUnsavedChanges = true;
+    updateLocalNoteCache(state.currentNoteId, { title: event.target.value });
+    const activeTitle = ui.notesContainer.querySelector(
+      `.note-card[data-note-id="${state.currentNoteId}"] .note-card-title`
+    );
+    if (activeTitle) {
+      activeTitle.textContent =
+        state.currentNote.title && state.currentNote.title.trim()
+          ? state.currentNote.title.trim()
+          : "Sans titre";
+    }
+    updateActiveNoteHighlight();
+    updateSaveStatus("dirty");
+    scheduleSave();
+  }
+
+  function handleEditorInput() {
+    if (!state.currentNote) return;
+    state.currentNote.contentHtml = ui.noteEditor.innerHTML;
+    state.hasUnsavedChanges = true;
+    updateSaveStatus("dirty");
+    scheduleSave();
+  }
+
+  function scheduleSave() {
+    if (!state.currentNote) return;
+    if (state.pendingSave) {
+      clearTimeout(state.pendingSave);
+    }
+    state.pendingSave = setTimeout(() => {
+      state.pendingSave = null;
+      saveCurrentNote().catch((error) => {
+        console.error("Erreur lors de l'enregistrement", error);
+        updateSaveStatus("error");
+        showToast("Impossible d'enregistrer la fiche", "error");
+      });
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  async function saveCurrentNote() {
+    if (!state.currentNote || !state.pseudo || !state.currentNoteId) return;
+    if (!state.hasUnsavedChanges) return;
+    updateSaveStatus("saving");
+    const noteRef = doc(db, "users", state.pseudo, "notes", state.currentNoteId);
+    const payload = {
+      title: (state.currentNote.title || "").trim(),
+      contentHtml: sanitizeHtml(state.currentNote.contentHtml || ""),
+      updatedAt: serverTimestamp()
+    };
+    try {
+      await updateDoc(noteRef, payload);
+      state.hasUnsavedChanges = false;
+      state.lastSavedAt = new Date();
+      state.currentNote.updatedAt = state.lastSavedAt;
+      updateLocalNoteCache(state.currentNoteId, { updatedAt: state.lastSavedAt });
+      const meta = ui.notesContainer.querySelector(
+        `.note-card[data-note-id="${state.currentNoteId}"] .note-card-meta`
+      );
+      if (meta) {
+        meta.textContent = formatRelativeDate(state.lastSavedAt);
+      }
+      updateSaveStatus("saved", state.lastSavedAt);
+    } catch (error) {
+      state.hasUnsavedChanges = true;
+      throw error;
+    }
+  }
+
+  async function flushPendingSave() {
+    if (state.pendingSave) {
+      clearTimeout(state.pendingSave);
+      state.pendingSave = null;
+    }
+    if (state.hasUnsavedChanges) {
+      await saveCurrentNote();
+    }
+  }
+
+  function handleToolbarClick(event) {
+    const button = event.target.closest("button[data-command]");
+    if (!button || !state.currentNote) return;
+    const command = button.dataset.command;
+    if (!command) return;
+    const value = button.dataset.value || null;
+    document.execCommand(command, false, value);
+    ui.noteEditor.focus();
+  }
+
+  async function createNote() {
+    if (!state.pseudo) return;
+    try {
+      const notesRef = collection(db, "users", state.pseudo, "notes");
+      const docRef = await addDoc(notesRef, {
+        title: "Nouvelle fiche",
+        contentHtml: "",
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+      });
+      state.pendingSelectionId = docRef.id;
+      showToast("Fiche créée", "success");
+    } catch (error) {
+      console.error("Impossible de créer la fiche", error);
+      showToast("Impossible de créer la fiche", "error");
+    }
+  }
+
+  async function deleteNote(noteId) {
+    if (!state.pseudo || !noteId) return;
+    const note = state.notes.find((item) => item.id === noteId);
+    const confirmed = window.confirm(`Supprimer la fiche "${note?.title || "Sans titre"}" ?`);
+    if (!confirmed) return;
+    try {
+      await flushPendingSave();
+      await deleteDoc(doc(db, "users", state.pseudo, "notes", noteId));
+      if (state.currentNoteId === noteId) {
+        state.currentNoteId = null;
+        state.currentNote = null;
+        state.hasUnsavedChanges = false;
+        showEmptyEditor();
+      }
+      showToast("Fiche supprimée", "success");
+    } catch (error) {
+      throw error;
+    }
   }
 
   async function ensureUserExists(pseudo) {
@@ -273,7 +559,47 @@ function bootstrapApp() {
     }
   }
 
-  function handleLoginSubmit(event) {
+  function subscribeToNotes() {
+    if (!state.pseudo) return;
+    const ref = collection(db, "users", state.pseudo, "notes");
+    const q = query(ref, orderBy("updatedAt", "desc"));
+    if (state.notesUnsubscribe) {
+      state.notesUnsubscribe();
+    }
+    state.notesUnsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        updateNotesFromSnapshot(snapshot);
+      },
+      (error) => {
+        console.error("Erreur lors du chargement des fiches", error);
+        showToast("Impossible de charger vos fiches", "error");
+      }
+    );
+  }
+
+  function resetState() {
+    if (state.notesUnsubscribe) {
+      state.notesUnsubscribe();
+      state.notesUnsubscribe = null;
+    }
+    if (state.pendingSave) {
+      clearTimeout(state.pendingSave);
+      state.pendingSave = null;
+    }
+    state.notes = [];
+    state.currentNoteId = null;
+    state.currentNote = null;
+    state.pendingSelectionId = null;
+    state.hasUnsavedChanges = false;
+    state.lastSavedAt = null;
+    ui.notesContainer.innerHTML = "";
+    showEmptyEditor();
+    ui.currentUser.textContent = "";
+    ui.logoutBtn.disabled = true;
+  }
+
+  async function handleLoginSubmit(event) {
     event.preventDefault();
     const { pseudoKey, displayName } = normalizePseudoInput(ui.pseudoInput.value);
     if (!pseudoKey || pseudoKey.length < MIN_PSEUDO_LENGTH) {
@@ -283,44 +609,40 @@ function bootstrapApp() {
       );
       return;
     }
-    if (ui.loginButton) {
-      ui.loginButton.disabled = true;
-    }
+    ui.loginButton.disabled = true;
     ui.pseudoInput.disabled = true;
-    login(pseudoKey, displayName)
-      .catch((err) => {
-        console.error(err);
-        let message = "Impossible de se connecter";
-        switch (err?.code) {
-          case "auth/invalid-email":
-          case "auth/missing-email":
-            message = "Pseudo invalide. Vérifiez les caractères utilisés.";
-            break;
-          case "auth/configuration-not-found":
-          case "auth/operation-not-allowed":
-            message =
-              "La connexion par e-mail/mot de passe n'est pas configurée pour ce projet Firebase ou l'application pointe vers une configuration incomplète. Vérifiez votre fichier firebase-config.js puis activez la méthode 'Email/Mot de passe' dans Firebase Authentication.";
-            break;
-          case "auth/too-many-requests":
-            message = "Trop de tentatives de connexion. Réessayez plus tard.";
-            break;
-          case "auth/network-request-failed":
-            message = "Connexion réseau requise pour accéder à votre compte.";
-            break;
-          case "auth/wrong-password":
-            message = "Ce pseudo est associé à un mot de passe différent. Contactez un administrateur.";
-            break;
-          default:
-            break;
-        }
-        showToast(message, "error");
-      })
-      .finally(() => {
-        if (ui.loginButton) {
-          ui.loginButton.disabled = false;
-        }
-        ui.pseudoInput.disabled = false;
-      });
+    try {
+      await login(pseudoKey, displayName);
+    } catch (error) {
+      console.error(error);
+      let message = "Impossible de se connecter";
+      switch (error?.code) {
+        case "auth/invalid-email":
+        case "auth/missing-email":
+          message = "Pseudo invalide. Vérifiez les caractères utilisés.";
+          break;
+        case "auth/configuration-not-found":
+        case "auth/operation-not-allowed":
+          message =
+            "La connexion e-mail/mot de passe n'est pas configurée. Vérifiez firebase-config.js puis activez la méthode 'Email/Mot de passe' dans Firebase Authentication.";
+          break;
+        case "auth/too-many-requests":
+          message = "Trop de tentatives de connexion. Réessayez plus tard.";
+          break;
+        case "auth/network-request-failed":
+          message = "Connexion réseau requise pour accéder à vos fiches.";
+          break;
+        case "auth/wrong-password":
+          message = "Ce pseudo est déjà utilisé avec un autre mot de passe.";
+          break;
+        default:
+          break;
+      }
+      showToast(message, "error");
+    } finally {
+      ui.loginButton.disabled = false;
+      ui.pseudoInput.disabled = false;
+    }
   }
 
   async function login(pseudoKey, displayName) {
@@ -333,30 +655,19 @@ function bootstrapApp() {
         credential = await signInWithEmailAndPassword(auth, email, password);
       } catch (error) {
         if (error?.code === "auth/user-not-found" || error?.code === "auth/invalid-credential") {
-          try {
-            credential = await createUserWithEmailAndPassword(auth, email, password);
-            if (credential.user && displayName) {
-              try {
-                await updateProfile(credential.user, { displayName });
-              } catch (profileError) {
-                console.warn("Impossible de mettre à jour le profil", profileError);
-              }
+          credential = await createUserWithEmailAndPassword(auth, email, password);
+          if (credential.user && displayName) {
+            try {
+              await updateProfile(credential.user, { displayName });
+            } catch (profileError) {
+              console.warn("Impossible de mettre à jour le profil", profileError);
             }
-          } catch (createError) {
-            if (createError?.code === "auth/email-already-in-use") {
-              const wrongPasswordError = new Error(
-                "Ce pseudo est associé à un mot de passe différent. Contactez un administrateur."
-              );
-              wrongPasswordError.code = "auth/wrong-password";
-              throw wrongPasswordError;
-            }
-            throw createError;
           }
         } else {
           throw error;
         }
       }
-      const currentUser = auth.currentUser;
+      const currentUser = credential?.user || auth.currentUser;
       if (currentUser && displayName && currentUser.displayName !== displayName) {
         try {
           await updateProfile(currentUser, { displayName });
@@ -397,778 +708,19 @@ function bootstrapApp() {
     ui.currentUser.textContent = `Connecté en tant que ${resolvedDisplayName}`;
     ui.logoutBtn.disabled = false;
     ui.loginForm.reset();
-
-    try {
-      await ensureUserExists(pseudoKey);
-    } catch (error) {
-      console.error("Impossible d'initialiser le profil Firestore", error);
-      showToast("Impossible de préparer votre compte", "error");
-      await signOut(auth);
-      return;
-    }
-
-    subscribeToCourses();
-    showView("dashboard");
+    subscribeToNotes();
+    showView("workspace");
   }
 
   async function logout() {
     ui.logoutBtn.disabled = true;
     try {
+      await flushPendingSave();
       await signOut(auth);
     } catch (error) {
       console.error(error);
       ui.logoutBtn.disabled = false;
       showToast("Impossible de se déconnecter", "error");
-    }
-  }
-
-  function subscribeToCourses() {
-    if (!state.pseudo) return;
-    const ref = collection(db, "users", state.pseudo, "courses");
-    const q = query(ref, orderBy("createdAt", "asc"));
-    if (state.coursesUnsubscribe) {
-      state.coursesUnsubscribe();
-    }
-    state.coursesUnsubscribe = onSnapshot(q, (snapshot) => {
-      state.courses = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
-      renderCourses();
-    });
-  }
-
-  function renderCourses() {
-    ui.coursesList.innerHTML = "";
-    if (state.courses.length === 0) {
-      const empty = document.createElement("p");
-      empty.className = "muted";
-      empty.textContent = "Aucun cours pour le moment. Créez votre premier cours !";
-      ui.coursesList.appendChild(empty);
-      return;
-    }
-
-    state.courses.forEach((course) => {
-      const card = document.createElement("div");
-      card.className = "course-card";
-      const title = document.createElement("h3");
-      title.textContent = course.name;
-      card.appendChild(title);
-
-      if (course.description) {
-        const desc = document.createElement("p");
-        desc.textContent = course.description;
-        card.appendChild(desc);
-      }
-
-      const actions = document.createElement("div");
-      actions.className = "course-card-actions";
-
-      const openBtn = document.createElement("button");
-      openBtn.textContent = "Ouvrir";
-      openBtn.addEventListener("click", () => openCourse(course));
-
-      const deleteBtn = document.createElement("button");
-      deleteBtn.textContent = "Supprimer";
-      deleteBtn.className = "secondary";
-      deleteBtn.addEventListener("click", () => deleteCourse(course));
-
-      actions.appendChild(openBtn);
-      actions.appendChild(deleteBtn);
-      card.appendChild(actions);
-      ui.coursesList.appendChild(card);
-    });
-  }
-
-  async function deleteCourse(course) {
-    if (!state.pseudo || !course) return;
-    const confirmed = window.confirm(`Supprimer le cours "${course.name}" ?`);
-    if (!confirmed) return;
-
-    try {
-      const pagesRef = collection(db, "users", state.pseudo, "courses", course.id, "pages");
-      const snapshot = await getDocs(pagesRef);
-      const batch = writeBatch(db);
-      snapshot.forEach((docSnap) => {
-        batch.delete(docSnap.ref);
-      });
-      batch.delete(doc(db, "users", state.pseudo, "courses", course.id));
-      await batch.commit();
-      showToast("Cours supprimé");
-    } catch (error) {
-      console.error(error);
-      showToast("Erreur lors de la suppression", "error");
-    }
-  }
-
-  async function handleNewCourse(event) {
-    event.preventDefault();
-    const name = ui.newCourseName.value.trim();
-    if (!name || !state.pseudo) return;
-    try {
-      await addDoc(collection(db, "users", state.pseudo, "courses"), {
-        name,
-        createdAt: serverTimestamp()
-      });
-      ui.newCourseName.value = "";
-      showToast("Cours créé");
-    } catch (error) {
-      console.error(error);
-      showToast("Impossible de créer le cours", "error");
-    }
-  }
-
-  function openCourse(course) {
-    state.currentCourse = course;
-    state.pages = [];
-    state.currentPage = null;
-    ui.pagesTree.innerHTML = "";
-    ui.editor.innerHTML = "";
-    ui.revisionContent.innerHTML = "";
-    ui.pageEmpty.classList.remove("hidden");
-    togglePagePanels(false);
-    ui.courseTitle.textContent = course.name;
-    showView("course");
-    subscribeToPages();
-    switchToTab("editor");
-  }
-
-  function subscribeToPages() {
-    if (!state.pseudo || !state.currentCourse) return;
-    const ref = collection(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages");
-    const q = query(ref, orderBy("order", "asc"));
-    if (state.pagesUnsubscribe) {
-      state.pagesUnsubscribe();
-    }
-    state.pagesUnsubscribe = onSnapshot(q, (snapshot) => {
-      state.pages = snapshot.docs.map((docSnap) => {
-        const data = docSnap.data();
-        return {
-          id: docSnap.id,
-          ...data,
-          clozeStates: normalizeClozeStates(data.clozeStates || {})
-        };
-      });
-      renderPagesTree();
-      updateParentOptions();
-      if (state.currentPage) {
-        const fresh = state.pages.find((page) => page.id === state.currentPage.id);
-        if (fresh) {
-          state.currentPage = {
-            ...fresh,
-            clozeStates: normalizeClozeStates(fresh.clozeStates || {})
-          };
-          loadPageIntoEditor(state.currentPage);
-        } else {
-          state.currentPage = null;
-          ui.editor.innerHTML = "";
-          ui.revisionContent.innerHTML = "";
-          ui.pageEmpty.classList.remove("hidden");
-          togglePagePanels(false);
-        }
-      }
-    });
-  }
-
-  function updateParentOptions() {
-    ui.parentSelect.innerHTML = "";
-    const defaultOption = document.createElement("option");
-    defaultOption.value = "";
-    defaultOption.textContent = "(niveau principal)";
-    ui.parentSelect.appendChild(defaultOption);
-
-    const buildOptions = (nodes, depth = 0) => {
-      nodes.forEach((node) => {
-        const option = document.createElement("option");
-        option.value = node.id;
-        option.textContent = `${"\u00A0".repeat(depth * 2)}${node.title}`;
-        ui.parentSelect.appendChild(option);
-        if (node.children && node.children.length > 0) {
-          buildOptions(node.children, depth + 1);
-        }
-      });
-    };
-
-    const tree = buildPageTree();
-    buildOptions(tree);
-  }
-
-  function buildPageTree() {
-    const map = new Map();
-    const nodes = state.pages.map((page) => ({ ...page, children: [] }));
-    nodes.forEach((node) => map.set(node.id, node));
-    const roots = [];
-    nodes.forEach((node) => {
-      if (node.parentId) {
-        const parent = map.get(node.parentId);
-        if (parent) {
-          parent.children.push(node);
-        } else {
-          roots.push(node);
-        }
-      } else {
-        roots.push(node);
-      }
-    });
-
-    const sortNodes = (list) => {
-      list.sort((a, b) => (a.order || 0) - (b.order || 0));
-      list.forEach((node) => sortNodes(node.children));
-    };
-    sortNodes(roots);
-    return roots;
-  }
-
-  function renderPagesTree() {
-    ui.pagesTree.innerHTML = "";
-    const tree = buildPageTree();
-    if (tree.length === 0) {
-      const empty = document.createElement("p");
-      empty.className = "muted";
-      empty.textContent = "Ajoutez un chapitre pour commencer.";
-      ui.pagesTree.appendChild(empty);
-      return;
-    }
-
-    const buildList = (nodes) => {
-      const ul = document.createElement("ul");
-      nodes.forEach((node) => {
-        const li = document.createElement("li");
-        const title = document.createElement("div");
-        title.className = "node-title";
-        title.textContent = node.title || "Sans titre";
-        title.addEventListener("click", () => selectPage(node));
-        if (state.currentPage && state.currentPage.id === node.id) {
-          li.classList.add("active");
-        }
-        li.appendChild(title);
-
-        const actions = document.createElement("div");
-        actions.className = "node-actions";
-        const renameBtn = document.createElement("button");
-        renameBtn.textContent = "Renommer";
-        renameBtn.className = "secondary";
-        renameBtn.addEventListener("click", (event) => {
-          event.stopPropagation();
-          renamePage(node);
-        });
-        const deleteBtn = document.createElement("button");
-        deleteBtn.textContent = "Supprimer";
-        deleteBtn.className = "secondary";
-        deleteBtn.addEventListener("click", (event) => {
-          event.stopPropagation();
-          deletePage(node);
-        });
-        actions.appendChild(renameBtn);
-        actions.appendChild(deleteBtn);
-        li.appendChild(actions);
-
-        if (node.children && node.children.length > 0) {
-          li.appendChild(buildList(node.children));
-        }
-        ul.appendChild(li);
-      });
-      return ul;
-    };
-
-    ui.pagesTree.appendChild(buildList(tree));
-  }
-
-  function selectPage(page) {
-    state.currentPage = {
-      ...page,
-      clozeStates: normalizeClozeStates(page.clozeStates || {})
-    };
-    loadPageIntoEditor(state.currentPage);
-    switchToTab(ui.editorTab.classList.contains("active") ? "editor" : "revision");
-  }
-
-  function loadPageIntoEditor(page) {
-    if (!page) {
-      togglePagePanels(false);
-      ui.pageEmpty.classList.remove("hidden");
-      return;
-    }
-    ui.pageEmpty.classList.add("hidden");
-    togglePagePanels(true);
-    ui.editor.innerHTML = page.contentHtml || "";
-    const normalizedStates = normalizeClozeStates(page.clozeStates || {});
-    state.currentClozeStates = normalizedStates;
-    state.currentPage = {
-      ...(state.currentPage || {}),
-      ...page,
-      clozeStates: normalizedStates
-    };
-    state.revisionHandlers.clear();
-    ui.revisionContent.innerHTML = "";
-    ui.saveStatus.textContent = "";
-    renderRevisionView();
-  }
-
-  function togglePagePanels(visible) {
-    if (!visible) {
-      ui.editorView.classList.add("hidden");
-      ui.revisionView.classList.add("hidden");
-    } else {
-      const editorActive = ui.editorTab.classList.contains("active");
-      ui.editorView.classList.toggle("hidden", !editorActive);
-      ui.revisionView.classList.toggle("hidden", editorActive);
-    }
-  }
-
-  function switchToTab(target) {
-    if (!state.currentPage) {
-      togglePagePanels(false);
-      return;
-    }
-    if (target === "editor") {
-      ui.editorTab.classList.add("active");
-      ui.revisionTab.classList.remove("active");
-      ui.editorView.classList.remove("hidden");
-      ui.revisionView.classList.add("hidden");
-    } else {
-      ui.revisionTab.classList.add("active");
-      ui.editorTab.classList.remove("active");
-      ui.revisionView.classList.remove("hidden");
-      ui.editorView.classList.add("hidden");
-      renderRevisionView();
-    }
-  }
-
-  function handleAddRootPage() {
-    if (!state.pseudo || !state.currentCourse) return;
-    const title = window.prompt("Nom du chapitre ?");
-    if (!title) return;
-    createPage(title, null);
-  }
-
-  function handleAddPage(event) {
-    event.preventDefault();
-    const title = ui.pageTitleInput.value.trim();
-    if (!title) return;
-    const parentId = ui.parentSelect.value || null;
-    createPage(title, parentId);
-    ui.pageTitleInput.value = "";
-  }
-
-  async function createPage(title, parentId) {
-    if (!state.pseudo || !state.currentCourse) return;
-    try {
-      await addDoc(collection(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages"), {
-        title,
-        parentId: parentId || null,
-        order: Date.now(),
-        contentHtml: "",
-        clozeStates: {},
-        createdAt: serverTimestamp()
-      });
-      showToast("Page créée");
-    } catch (error) {
-      console.error(error);
-      showToast("Erreur lors de la création", "error");
-    }
-  }
-
-  async function renamePage(page) {
-    if (!state.pseudo || !state.currentCourse || !page) return;
-    const title = window.prompt("Nouveau titre", page.title || "");
-    if (!title) return;
-    try {
-      await updateDoc(doc(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages", page.id), {
-        title
-      });
-      showToast("Titre mis à jour");
-    } catch (error) {
-      console.error(error);
-      showToast("Impossible de renommer", "error");
-    }
-  }
-
-  async function deletePage(page) {
-    if (!state.pseudo || !state.currentCourse || !page) return;
-    const confirmed = window.confirm(`Supprimer "${page.title}" et ses sous-pages ?`);
-    if (!confirmed) return;
-    try {
-      const descendants = collectDescendants(page.id);
-      const batch = writeBatch(db);
-      descendants.forEach((id) => {
-        batch.delete(doc(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages", id));
-      });
-      batch.delete(doc(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages", page.id));
-      await batch.commit();
-      if (state.currentPage && state.currentPage.id === page.id) {
-        state.currentPage = null;
-        ui.editor.innerHTML = "";
-        ui.revisionContent.innerHTML = "";
-        ui.pageEmpty.classList.remove("hidden");
-        togglePagePanels(false);
-      }
-      showToast("Page supprimée");
-    } catch (error) {
-      console.error(error);
-      showToast("Erreur lors de la suppression", "error");
-    }
-  }
-
-  function collectDescendants(pageId) {
-    const result = [];
-    const queue = [pageId];
-    while (queue.length > 0) {
-      const current = queue.shift();
-      state.pages.forEach((page) => {
-        if (page.parentId === current) {
-          result.push(page.id);
-          queue.push(page.id);
-        }
-      });
-    }
-    return result;
-  }
-
-  function handleToolbarClick(event) {
-    const button = event.target.closest("button");
-    if (!button) return;
-    const command = button.dataset.command;
-    if (!command) return;
-    const value = button.dataset.value || null;
-    document.execCommand(command, false, value);
-    ui.editor.focus();
-  }
-
-  function insertImage() {
-    const url = window.prompt("URL de l'image");
-    if (!url) return;
-    document.execCommand("insertImage", false, url);
-  }
-
-  function selectionInsideEditor() {
-    const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return null;
-    const range = selection.getRangeAt(0);
-    if (!ui.editor.contains(range.commonAncestorContainer)) {
-      return null;
-    }
-    return { selection, range };
-  }
-
-  function createCloze() {
-    const context = selectionInsideEditor();
-    if (!context) {
-      showToast("Sélectionnez un texte dans l'éditeur", "warning");
-      return;
-    }
-    const { selection, range } = context;
-    if (selection.isCollapsed) {
-      showToast("Sélection vide", "warning");
-      return;
-    }
-    const startNode = range.startContainer.nodeType === Node.ELEMENT_NODE
-      ? range.startContainer
-      : range.startContainer.parentElement;
-    const endNode = range.endContainer.nodeType === Node.ELEMENT_NODE
-      ? range.endContainer
-      : range.endContainer.parentElement;
-    if ((startNode && startNode.closest(".cloze")) || (endNode && endNode.closest(".cloze"))) {
-      showToast("La sélection contient déjà un trou", "warning");
-      return;
-    }
-    const text = selection.toString();
-    if (!text.trim()) {
-      showToast("Sélection invalide", "warning");
-      return;
-    }
-    const span = document.createElement("span");
-    span.className = "cloze";
-    const id = safeId();
-    span.dataset.id = id;
-    span.dataset.answer = text;
-    span.dataset.counter = "0";
-    span.dataset.score = "0";
-    span.textContent = text;
-    range.deleteContents();
-    range.insertNode(span);
-    const newRange = document.createRange();
-    newRange.setStartAfter(span);
-    newRange.collapse(true);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-    updateClozeStatesFromEditor();
-  }
-
-  function removeCloze() {
-    const context = selectionInsideEditor();
-    if (!context) {
-      showToast("Sélectionnez un trou", "warning");
-      return;
-    }
-    const { selection, range } = context;
-    let node = range.startContainer;
-    if (node.nodeType === Node.TEXT_NODE) {
-      node = node.parentElement;
-    }
-    const cloze = node && node.closest(".cloze");
-    if (!cloze || !ui.editor.contains(cloze)) {
-      showToast("Aucun trou ici", "warning");
-      return;
-    }
-    const text = cloze.textContent;
-    const textNode = document.createTextNode(text);
-    cloze.replaceWith(textNode);
-    selection.removeAllRanges();
-    const newRange = document.createRange();
-    newRange.setStart(textNode, textNode.length);
-    newRange.collapse(true);
-    selection.addRange(newRange);
-    const id = cloze.dataset.id;
-    if (id && state.currentClozeStates[id]) {
-      delete state.currentClozeStates[id];
-    }
-    updateClozeStatesFromEditor();
-  }
-
-  function updateClozeStatesFromEditor() {
-    const spans = ui.editor.querySelectorAll("span.cloze");
-    const updated = {};
-    spans.forEach((span) => {
-      let id = span.dataset.id;
-      if (!id) {
-        id = safeId();
-        span.dataset.id = id;
-      }
-      const previous = normalizeClozeStateEntry(state.currentClozeStates[id] || {});
-      const answer = span.textContent;
-      const score = previous.score;
-      const fallbackCounter = Math.max(0, Math.floor(score));
-      const rawCounter = previous.counter ?? Number(span.dataset.counter || fallbackCounter);
-      const counter = Math.max(0, Math.min(fallbackCounter, Number(rawCounter || 0)));
-      span.dataset.answer = answer;
-      span.dataset.counter = String(counter);
-      span.dataset.score = String(score);
-      updated[id] = {
-        answer,
-        counter,
-        score
-      };
-    });
-    state.currentClozeStates = normalizeClozeStates(updated);
-    if (state.currentPage) {
-      state.currentPage = {
-        ...state.currentPage,
-        clozeStates: state.currentClozeStates
-      };
-    }
-  }
-
-  async function savePage() {
-    if (!state.currentPage || !state.pseudo || !state.currentCourse) return;
-    updateClozeStatesFromEditor();
-    ui.saveButton.disabled = true;
-    ui.saveStatus.textContent = "Enregistrement...";
-    try {
-      const normalizedStates = normalizeClozeStates(state.currentClozeStates);
-      await updateDoc(doc(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages", state.currentPage.id), {
-        contentHtml: ui.editor.innerHTML,
-        clozeStates: normalizedStates,
-        updatedAt: serverTimestamp()
-      });
-      state.currentPage = {
-        ...state.currentPage,
-        contentHtml: ui.editor.innerHTML,
-        clozeStates: normalizedStates
-      };
-      state.pages = state.pages.map((page) =>
-        page.id === state.currentPage.id
-          ? {
-              ...page,
-              contentHtml: state.currentPage.contentHtml,
-              clozeStates: normalizeClozeStates(state.currentPage.clozeStates)
-            }
-          : page
-      );
-      renderRevisionView();
-      ui.saveStatus.textContent = "Enregistré";
-      showToast("Page sauvegardée", "success");
-    } catch (error) {
-      console.error(error);
-      ui.saveStatus.textContent = "Erreur";
-      showToast("Impossible d'enregistrer", "error");
-    } finally {
-      ui.saveButton.disabled = false;
-      setTimeout(() => {
-        ui.saveStatus.textContent = "";
-      }, 2000);
-    }
-  }
-
-  function renderRevisionView() {
-    if (!state.currentPage) {
-      ui.revisionContent.innerHTML = "";
-      return;
-    }
-    ui.revisionContent.innerHTML = state.currentPage.contentHtml || "<p class=\"muted\">Aucun contenu enregistré.</p>";
-    state.revisionHandlers.clear();
-    const spans = ui.revisionContent.querySelectorAll("span.cloze");
-    spans.forEach((span) => {
-      const id = span.dataset.id;
-      const stateData = normalizeClozeStateEntry(
-        (state.currentPage.clozeStates || {})[id] || { answer: span.textContent }
-      );
-      span.dataset.answer = stateData.answer;
-      span.dataset.counter = stateData.counter;
-      span.dataset.score = stateData.score;
-      span.textContent = stateData.answer;
-      span.classList.remove("needs-review");
-      span.dataset.reviewed = "false";
-      if (Number(stateData.counter || 0) <= 0) {
-        span.classList.add("needs-review");
-        span.textContent = "";
-        const handler = () => handleClozeReveal(span);
-        span.addEventListener("click", handler);
-        state.revisionHandlers.set(id, handler);
-      }
-    });
-  }
-
-  function handleClozeReveal(span) {
-    const id = span.dataset.id;
-    const stateData = (state.currentPage?.clozeStates || {})[id];
-    if (!stateData) return;
-    if (!span.classList.contains("needs-review")) return;
-    span.classList.remove("needs-review");
-    span.textContent = stateData.answer;
-    span.dataset.reviewed = "true";
-    const handler = state.revisionHandlers.get(id);
-    if (handler) {
-      span.removeEventListener("click", handler);
-      state.revisionHandlers.delete(id);
-    }
-    const panel = createRatingPanel(id, span);
-    span.insertAdjacentElement("afterend", panel);
-  }
-
-  function createRatingPanel(id, span) {
-    const panel = document.createElement("div");
-    panel.className = "rating-panel";
-    const options = [
-      { key: "yes", label: "✅ Oui", delta: 1, reset: false },
-      { key: "almost", label: "🙂 Plutôt oui", delta: 0.5, reset: false },
-      { key: "neutral", label: "😐 Neutre", delta: 0, reset: true },
-      { key: "almost-no", label: "🤔 Plutôt non", delta: 0, reset: true },
-      { key: "no", label: "❌ Non", delta: 0, reset: true }
-    ];
-    options.forEach((option) => {
-      const button = document.createElement("button");
-      button.type = "button";
-      button.textContent = option.label;
-      button.addEventListener("click", () => rateCloze(id, option, panel, span));
-      panel.appendChild(button);
-    });
-    return panel;
-  }
-
-  async function rateCloze(id, option, panel, span) {
-    if (!state.currentPage || !state.currentCourse || !state.pseudo) return;
-    const pageRef = doc(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages", state.currentPage.id);
-    const current = normalizeClozeStateEntry(
-      (state.currentPage.clozeStates || {})[id] || { answer: span.dataset.answer || "" }
-    );
-    const baseScore = option.reset ? 0 : Math.max(0, Number(current.score || 0));
-    const newScore = option.reset
-      ? 0
-      : Number((baseScore + option.delta).toFixed(2));
-    const newCounter = option.reset
-      ? 0
-      : Math.max(0, Math.floor(newScore));
-    const newState = {
-      answer: current.answer,
-      counter: newCounter,
-      score: newScore
-    };
-    try {
-      await updateDoc(pageRef, {
-        [`clozeStates.${id}`]: newState
-      });
-      state.currentPage.clozeStates = {
-        ...state.currentPage.clozeStates,
-        [id]: newState
-      };
-      state.currentClozeStates = {
-        ...state.currentClozeStates,
-        [id]: newState
-      };
-      state.currentPage.clozeStates = normalizeClozeStates(state.currentClozeStates);
-      state.pages = state.pages.map((page) =>
-        page.id === state.currentPage.id
-          ? { ...page, clozeStates: normalizeClozeStates(state.currentPage.clozeStates) }
-          : page
-      );
-      span.dataset.counter = newCounter;
-      span.dataset.score = newScore;
-      panel.remove();
-      showToast("Réponse enregistrée", "success");
-    } catch (error) {
-      console.error(error);
-      showToast("Erreur lors de l'évaluation", "error");
-    }
-  }
-
-  async function runIteration() {
-    if (!state.currentCourse || !state.pseudo) return;
-    const confirmed = window.confirm("Lancer une nouvelle itération ?");
-    if (!confirmed) return;
-    try {
-      const pagesRef = collection(db, "users", state.pseudo, "courses", state.currentCourse.id, "pages");
-      const snapshot = await getDocs(pagesRef);
-      const batch = writeBatch(db);
-      snapshot.forEach((docSnap) => {
-        const data = docSnap.data();
-        if (!data.clozeStates) return;
-        const updated = {};
-        Object.entries(data.clozeStates).forEach(([key, value]) => {
-          const normalized = normalizeClozeStateEntry(value || {});
-          const decremented = Math.max(0, Number((normalized.counter ?? 0) - 1));
-          const maxCounter = Math.max(0, Math.floor(normalized.score));
-          const counter = Math.min(maxCounter, decremented);
-          updated[key] = {
-            answer: normalized.answer,
-            counter,
-            score: normalized.score
-          };
-        });
-        batch.update(docSnap.ref, { clozeStates: updated });
-      });
-      await batch.commit();
-      if (state.currentPage) {
-        const updated = {};
-        Object.entries(state.currentPage.clozeStates || {}).forEach(([key, value]) => {
-          const normalized = normalizeClozeStateEntry(value || {});
-          const decremented = Math.max(0, Number((normalized.counter ?? 0) - 1));
-          const maxCounter = Math.max(0, Math.floor(normalized.score));
-          updated[key] = {
-            answer: normalized.answer,
-            counter: Math.min(maxCounter, decremented),
-            score: normalized.score
-          };
-        });
-        const normalizedCurrent = normalizeClozeStates(updated);
-        state.currentPage = {
-          ...state.currentPage,
-          clozeStates: normalizedCurrent
-        };
-        state.currentClozeStates = normalizedCurrent;
-        state.pages = state.pages.map((page) =>
-          page.id === state.currentPage.id ? { ...page, clozeStates: normalizedCurrent } : page
-        );
-        ui.editor.querySelectorAll("span.cloze").forEach((span) => {
-          const data = normalizedCurrent[span.dataset.id];
-          if (data) {
-            span.dataset.counter = String(data.counter);
-            span.dataset.score = String(data.score);
-          }
-        });
-        renderRevisionView();
-      }
-      showToast("Itération appliquée", "success");
-    } catch (error) {
-      console.error(error);
-      showToast("Impossible d'appliquer l'itération", "error");
     }
   }
 
@@ -1189,33 +741,20 @@ function bootstrapApp() {
   function initEvents() {
     ui.loginForm.addEventListener("submit", handleLoginSubmit);
     ui.logoutBtn.addEventListener("click", logout);
-    ui.newCourseForm.addEventListener("submit", handleNewCourse);
-    ui.backToDashboard.addEventListener("click", () => {
-      showView("dashboard");
-      if (state.pagesUnsubscribe) {
-        state.pagesUnsubscribe();
-        state.pagesUnsubscribe = null;
-      }
-      state.currentCourse = null;
-      state.currentPage = null;
-      state.pages = [];
-      ui.pagesTree.innerHTML = "";
-      ui.editor.innerHTML = "";
-      ui.revisionContent.innerHTML = "";
-      ui.courseTitle.textContent = "";
-      ui.pageEmpty.classList.remove("hidden");
-      togglePagePanels(false);
+    ui.addNoteBtn.addEventListener("click", () => {
+      createNote().catch((error) => {
+        console.error(error);
+      });
     });
-    ui.addRootPage.addEventListener("click", handleAddRootPage);
-    ui.addPageForm.addEventListener("submit", handleAddPage);
-    editorToolbar.addEventListener("click", handleToolbarClick);
-    ui.insertImageBtn.addEventListener("click", insertImage);
-    ui.createClozeBtn.addEventListener("click", createCloze);
-    ui.removeClozeBtn.addEventListener("click", removeCloze);
-    ui.saveButton.addEventListener("click", savePage);
-    ui.editorTab.addEventListener("click", () => switchToTab("editor"));
-    ui.revisionTab.addEventListener("click", () => switchToTab("revision"));
-    ui.newIterationBtn.addEventListener("click", runIteration);
+    ui.noteTitle.addEventListener("input", handleTitleInput);
+    ui.noteEditor.addEventListener("input", handleEditorInput);
+    ui.toolbar.addEventListener("click", handleToolbarClick);
+    window.addEventListener("beforeunload", (event) => {
+      if (state.hasUnsavedChanges) {
+        event.preventDefault();
+        event.returnValue = "";
+      }
+    });
   }
 
   initEvents();

--- a/firestore.rules
+++ b/firestore.rules
@@ -7,16 +7,15 @@ service cloud.firestore {
     }
 
     function isOwner(userId) {
-      // Les comptes utilisent une adresse générée de la forme <pseudo>@pseudo.apprentissage (cf. app.js).
       return isSignedIn() && request.auth.token.email == userId + '@pseudo.apprentissage';
     }
 
-    function nonEmptyString(value, maxLen) {
-      return value is string && value.size() > 0 && value.size() <= maxLen;
+    function stringMax(value, maxLen) {
+      return value is string && value.size() <= maxLen;
     }
 
     function optionalString(value, maxLen) {
-      return value == null || (value is string && value.size() <= maxLen);
+      return value == null || stringMax(value, maxLen);
     }
 
     function isTimestamp(value) {
@@ -27,47 +26,12 @@ service cloud.firestore {
       return value == null || value is timestamp;
     }
 
-    function isValidCourse(data) {
-      return data.keys().hasOnly(['name', 'description', 'createdAt', 'updatedAt']) &&
-             'name' in data && nonEmptyString(data.name, 120) &&
-             (!('description' in data) || optionalString(data.description, 2000)) &&
+    function isValidNote(data) {
+      return data.keys().hasOnly(['title', 'contentHtml', 'createdAt', 'updatedAt']) &&
+             'title' in data && stringMax(data.title, 200) &&
+             'contentHtml' in data && optionalString(data.contentHtml, 50000) &&
              'createdAt' in data && isTimestamp(data.createdAt) &&
              (!('updatedAt' in data) || optionalTimestamp(data.updatedAt));
-    }
-
-    function isValidClozeState(entry) {
-      return entry is map &&
-             entry.keys().hasOnly(['answer', 'counter', 'score']) &&
-             'answer' in entry && optionalString(entry.answer, 2000) &&
-             'counter' in entry && entry.counter is int && entry.counter >= 0 &&
-             'score' in entry && entry.score is number && entry.score >= 0;
-    }
-
-    function areValidClozeStateValues(values) {
-      return values is list &&
-             values.size() <= 50 &&
-             values.where(value, !isValidClozeState(value)).size() == 0;
-    }
-
-    function isValidClozeStates(mapValue) {
-      return mapValue is map &&
-             areValidClozeStateValues(mapValue.values());
-    }
-
-    function isValidPage(data) {
-      return data.keys().hasOnly([
-               'title', 'parentId', 'order', 'contentHtml',
-               'clozeStates', 'createdAt', 'updatedAt'
-             ]) &&
-             'title' in data && nonEmptyString(data.title, 200) &&
-             'order' in data && data.order is number &&
-             'contentHtml' in data && data.contentHtml is string &&
-             'createdAt' in data && isTimestamp(data.createdAt) &&
-             (!('updatedAt' in data) || optionalTimestamp(data.updatedAt)) &&
-             (!('parentId' in data) ||
-               data.parentId == null ||
-               (data.parentId is string && data.parentId.size() <= 200)) &&
-             (!('clozeStates' in data) || isValidClozeStates(data.clozeStates));
     }
 
     match /users/{userId} {
@@ -78,32 +42,18 @@ service cloud.firestore {
                     isTimestamp(request.resource.data.createdAt);
 
       allow delete: if isOwner(userId);
-      // Pas d’update attendu sur le document utilisateur.
 
-      match /courses/{courseId} {
+      match /notes/{noteId} {
         allow read: if isOwner(userId);
 
         allow create: if isOwner(userId) &&
-                      isValidCourse(request.resource.data);
+                      isValidNote(request.resource.data);
 
         allow update: if isOwner(userId) &&
-                      isValidCourse(request.resource.data) &&
+                      isValidNote(request.resource.data) &&
                       request.resource.data.createdAt == resource.data.createdAt;
 
         allow delete: if isOwner(userId);
-
-        match /pages/{pageId} {
-          allow read: if isOwner(userId);
-
-          allow create: if isOwner(userId) &&
-                        isValidPage(request.resource.data);
-
-          allow update: if isOwner(userId) &&
-                        isValidPage(request.resource.data) &&
-                        request.resource.data.createdAt == resource.data.createdAt;
-
-          allow delete: if isOwner(userId);
-        }
       }
     }
   }

--- a/index.html
+++ b/index.html
@@ -4,101 +4,108 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apprentissage actif</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      rel="icon"
-      type="image/svg+xml"
-      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' ry='6' fill='%23204770'/%3E%3Cpath d='M9 23h3l4-6 4 6h3l-5.5-8L23 9h-3l-4 5.8L12 9H9l5.5 8z' fill='%23ffffff'/%3E%3C/svg%3E"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <header class="app-header">
-      <h1>Apprentissage actif</h1>
+      <div class="brand">
+        <h1>Apprentissage actif</h1>
+        <p class="subtitle">Des fiches simples, prêtes à apprendre.</p>
+      </div>
       <div class="header-actions">
         <span id="current-user" class="muted"></span>
         <button id="logout-btn" class="secondary">Se déconnecter</button>
       </div>
     </header>
 
-    <main>
+    <main class="app-main">
       <section id="login-screen" class="view active">
         <div class="card">
           <h2>Bienvenue !</h2>
-          <p>Choisissez un pseudo pour commencer vos révisions actives.</p>
+          <p>Choisissez un pseudo pour créer vos fiches d'apprentissage actives.</p>
           <form id="login-form" class="stack">
             <label for="pseudo">Pseudo</label>
-            <input id="pseudo" name="pseudo" type="text" required minlength="3" maxlength="32" />
-            <button type="submit">Entrer</button>
+            <input
+              id="pseudo"
+              name="pseudo"
+              type="text"
+              required
+              minlength="3"
+              maxlength="32"
+              autocomplete="nickname"
+              placeholder="ex.&nbsp;: astrofan"
+            />
+            <button type="submit">Commencer</button>
           </form>
+          <p class="muted small">
+            Astuce : vous pouvez revenir plus tard avec le même pseudo pour retrouver vos fiches.
+          </p>
         </div>
       </section>
 
-      <section id="dashboard-screen" class="view hidden">
-        <div class="toolbar">
-          <h2>Mes cours</h2>
-          <form id="new-course-form" class="inline">
-            <input type="text" id="new-course-name" placeholder="Nom du cours" required />
-            <button type="submit">Créer</button>
-          </form>
-        </div>
-        <div id="courses-list" class="cards"></div>
-      </section>
-
-      <section id="course-screen" class="view hidden">
-        <div class="toolbar course-toolbar">
-          <button id="back-to-dashboard" class="secondary">Retour</button>
-          <div class="course-title-area">
-            <h2 id="course-title"></h2>
-            <button id="new-iteration-btn" class="secondary">Nouvelle itération</button>
-          </div>
-        </div>
-        <div class="course-layout">
-          <aside class="sidebar">
-            <div class="sidebar-header">
-              <h3>Structure</h3>
-              <button id="add-root-page" class="secondary">Ajouter un chapitre</button>
+      <section id="workspace" class="view hidden">
+        <div class="workspace">
+          <aside class="note-list">
+            <div class="note-list-header">
+              <div>
+                <h2>Mes fiches</h2>
+                <p class="muted small">Tout est enregistré automatiquement.</p>
+              </div>
+              <button id="add-note-btn">Nouvelle fiche</button>
             </div>
-            <form id="add-page-form" class="stack">
-              <label for="page-title-input">Titre</label>
-              <input id="page-title-input" type="text" required />
-              <label for="parent-select">Parent</label>
-              <select id="parent-select"></select>
-              <button type="submit">Ajouter une page</button>
-            </form>
-            <div id="pages-tree" class="tree"></div>
+            <div id="notes-container" class="notes-container"></div>
           </aside>
-          <section class="content-area">
-            <div class="mode-switch">
-              <button id="editor-tab" class="tab active" data-target="editor-view">Éditeur</button>
-              <button id="revision-tab" class="tab" data-target="revision-view">Mode révision</button>
+
+          <section class="editor-area">
+            <div id="empty-note" class="empty-state">
+              <h2>Commencez par créer une fiche</h2>
+              <p>Ajoutez une fiche à gauche puis rédigez vos contenus ici.</p>
             </div>
-            <div id="page-empty" class="empty-state">Sélectionnez une page pour commencer.</div>
-            <div id="editor-view" class="panel hidden">
-              <div class="editor-toolbar">
-                <button type="button" data-command="bold"><span>Gras</span></button>
-                <button type="button" data-command="italic"><span>Italique</span></button>
-                <button type="button" data-command="insertUnorderedList"><span>Liste</span></button>
-                <button type="button" data-command="formatBlock" data-value="h2"><span>Titre</span></button>
-                <button type="button" id="insert-image-btn"><span>Image</span></button>
-                <button type="button" id="create-cloze-btn"><span>Texte à trou</span></button>
-                <button type="button" id="remove-cloze-btn"><span>Retirer le trou</span></button>
+
+            <div id="editor-wrapper" class="editor-wrapper hidden" aria-live="polite">
+              <div class="editor-header">
+                <input
+                  id="note-title"
+                  type="text"
+                  placeholder="Titre de la fiche"
+                  aria-label="Titre de la fiche"
+                />
+                <span id="save-status" class="save-status muted"></span>
               </div>
-              <div id="editor" contenteditable="true" class="editor" aria-label="Éditeur de cours"></div>
-              <div class="editor-actions">
-                <button id="save-page-btn">Enregistrer</button>
-                <span id="save-status" class="muted"></span>
+              <div class="editor-toolbar" aria-label="Outils de mise en forme">
+                <button type="button" class="ghost" data-command="bold" title="Gras (Ctrl+B)">
+                  <span>Gras</span>
+                </button>
+                <button type="button" class="ghost" data-command="italic" title="Italique (Ctrl+I)">
+                  <span>Italique</span>
+                </button>
+                <button type="button" class="ghost" data-command="insertUnorderedList" title="Liste">
+                  <span>Liste</span>
+                </button>
+                <button type="button" class="ghost" data-command="formatBlock" data-value="h2" title="Sous-titre">
+                  <span>Sous-titre</span>
+                </button>
               </div>
-            </div>
-            <div id="revision-view" class="panel hidden">
-              <div id="revision-content" class="revision"></div>
-              <p class="muted">Cliquez sur un trou pour révéler la réponse puis évaluez votre réussite.</p>
+              <div
+                id="note-editor"
+                class="editor"
+                contenteditable="true"
+                aria-label="Contenu de la fiche"
+                spellcheck="true"
+              ></div>
             </div>
           </section>
         </div>
       </section>
     </main>
 
-    <div id="toast" class="toast hidden"></div>
+    <div id="toast" class="toast hidden" role="status" aria-live="assertive"></div>
 
     <script type="module" src="app.js"></script>
   </body>

--- a/styles.css
+++ b/styles.css
@@ -1,14 +1,18 @@
 :root {
-  --bg: #f5f6fb;
-  --fg: #1f1f3d;
-  --accent: #5a67d8;
-  --accent-strong: #434190;
-  --border: #d8dbec;
-  --muted: #6b6c7b;
-  --card: #fff;
-  --success: #2f855a;
-  --warning: #dd6b20;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --bg: #f4f7fb;
+  --bg-gradient: radial-gradient(circle at top left, #eef2ff, rgba(238, 242, 255, 0) 45%),
+    radial-gradient(circle at bottom right, #e0f2fe, rgba(224, 242, 254, 0) 40%), #f4f7fb;
+  --fg: #1f2a44;
+  --accent: #4f46e5;
+  --accent-strong: #3730a3;
+  --border: #d9def3;
+  --muted: #6b7280;
+  --card: #ffffff;
+  --card-shadow: 0 20px 40px -24px rgba(31, 42, 68, 0.35);
+  --danger: #ef4444;
+  --success: #16a34a;
+  --warning: #f59e0b;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
@@ -17,9 +21,11 @@
 
 body {
   margin: 0;
-  background: var(--bg);
-  color: var(--fg);
   min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--fg);
+  display: flex;
+  flex-direction: column;
 }
 
 h1,
@@ -30,27 +36,36 @@ h4 {
   font-weight: 600;
 }
 
+p {
+  margin: 0;
+  line-height: 1.5;
+}
+
 button,
 input,
-select,
 textarea {
   font: inherit;
 }
 
 button {
-  background: var(--accent);
-  color: white;
   border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 0.6rem;
+  border-radius: 0.75rem;
+  padding: 0.55rem 1.1rem;
+  background: linear-gradient(135deg, var(--accent), #6366f1);
+  color: white;
+  font-weight: 500;
   cursor: pointer;
-  transition: background 0.2s ease;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  box-shadow: 0 12px 24px -18px rgba(79, 70, 229, 0.7);
 }
 
-button.secondary {
-  background: transparent;
-  color: var(--accent-strong);
-  border: 1px solid var(--accent-strong);
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 28px -18px rgba(79, 70, 229, 0.7);
+}
+
+button:active:not(:disabled) {
+  transform: translateY(0);
 }
 
 button:disabled {
@@ -58,42 +73,71 @@ button:disabled {
   cursor: not-allowed;
 }
 
-button:hover:not(:disabled) {
-  background: var(--accent-strong);
+button.secondary {
+  background: transparent;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  box-shadow: none;
 }
 
 button.secondary:hover:not(:disabled) {
-  background: var(--accent-strong);
-  color: white;
+  background: rgba(79, 70, 229, 0.08);
 }
 
-input,
-select,
-textarea {
+button.ghost {
+  background: transparent;
+  color: var(--fg);
+  border: 1px solid transparent;
+  box-shadow: none;
+  padding: 0.45rem 0.9rem;
+}
+
+button.ghost:hover {
+  background: rgba(79, 70, 229, 0.08);
+  border-color: rgba(79, 70, 229, 0.08);
+}
+
+input[type="text"] {
   width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.75rem;
   border: 1px solid var(--border);
-  border-radius: 0.6rem;
-  padding: 0.5rem 0.75rem;
   background: white;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type="text"]:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
 }
 
 .app-header {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background: var(--card);
-  border-bottom: 1px solid var(--border);
+  padding: 1.2rem 2.5rem;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(217, 222, 243, 0.6);
+  position: sticky;
+  top: 0;
+  z-index: 10;
 }
 
-.header-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
+.brand h1 {
+  font-size: 1.6rem;
 }
 
-main {
-  padding: 2rem;
+.subtitle {
+  font-size: 0.95rem;
+  color: var(--muted);
+  margin-top: 0.35rem;
+}
+
+.app-main {
+  flex: 1;
+  padding: 2rem 2.5rem 3rem;
 }
 
 .view {
@@ -104,25 +148,28 @@ main {
   display: block;
 }
 
-.view.hidden {
-  display: none;
+.hidden {
+  display: none !important;
 }
 
 .card {
-  max-width: 420px;
-  margin: 3rem auto;
-  padding: 2rem;
+  max-width: 440px;
+  margin: 4rem auto 0;
+  padding: 2.5rem 2.25rem;
   background: var(--card);
-  border-radius: 1rem;
-  box-shadow: 0 20px 40px -40px rgba(0, 0, 0, 0.3);
+  border-radius: 1.5rem;
+  box-shadow: var(--card-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
 .card.error {
-  border: 1px solid var(--warning);
+  border: 1px solid rgba(239, 68, 68, 0.6);
 }
 
 .card.error h2 {
-  color: var(--warning);
+  color: var(--danger);
 }
 
 .stack {
@@ -131,241 +178,210 @@ main {
   gap: 0.75rem;
 }
 
-.inline {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.cards {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.course-card {
-  padding: 1rem;
-  border-radius: 1rem;
-  background: var(--card);
-  border: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.75rem;
-}
-
-.course-card-actions {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.5rem;
-  margin-top: 0.25rem;
-}
-
-.course-card-actions button {
-  width: 100%;
-}
-
-@media (min-width: 700px) {
-  .course-card-actions {
-    flex-direction: row;
-    align-items: center;
-  }
-
-  .course-card-actions button {
-    width: auto;
-  }
-}
-
-.course-layout {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 1.5rem;
-}
-
-.sidebar {
-  background: var(--card);
-  border-radius: 1rem;
-  padding: 1rem;
-  border: 1px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  max-height: calc(100vh - 200px);
-  overflow: auto;
-}
-
-.sidebar-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.tree ul {
-  list-style: none;
-  padding-left: 1rem;
-  margin: 0;
-}
-
-.tree li {
-  padding: 0.35rem 0;
-  cursor: pointer;
-}
-
-.tree li.active > .node-title {
-  font-weight: 600;
-  color: var(--accent-strong);
-}
-
-.node-actions {
-  display: flex;
-  gap: 0.25rem;
-  margin-top: 0.25rem;
-}
-
-.node-actions button {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-}
-
-.content-area {
-  background: var(--card);
-  border-radius: 1rem;
-  border: 1px solid var(--border);
-  padding: 1rem;
-  min-height: 500px;
-  display: flex;
-  flex-direction: column;
-}
-
-.mode-switch {
-  display: inline-flex;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  margin-bottom: 1rem;
-  overflow: hidden;
-  align-self: flex-start;
-}
-
-.tab {
-  background: transparent;
-  border: none;
-  color: var(--muted);
-  padding: 0.5rem 1rem;
-}
-
-.tab.active {
-  background: var(--accent);
-  color: white;
-}
-
-.panel.hidden {
-  display: none;
-}
-
-.editor-toolbar {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-  margin-bottom: 0.75rem;
-}
-
-.editor-toolbar button {
-  background: var(--border);
-  color: var(--fg);
-  border-radius: 0.5rem;
-}
-
-.editor {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  min-height: 280px;
-  background: white;
-  overflow-y: auto;
-}
-
-.editor:focus {
-  outline: 2px solid var(--accent);
-}
-
-.editor-actions {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 1rem;
-}
-
 .muted {
   color: var(--muted);
 }
 
-.empty-state {
+.small {
+  font-size: 0.85rem;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 2rem;
+  align-items: stretch;
+}
+
+.note-list {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(217, 222, 243, 0.7);
+  box-shadow: var(--card-shadow);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 540px;
+}
+
+.note-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.notes-container {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow-y: auto;
+  max-height: calc(100vh - 220px);
+  padding-right: 0.25rem;
+}
+
+.notes-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.notes-container::-webkit-scrollbar-thumb {
+  background: rgba(79, 70, 229, 0.25);
+  border-radius: 3px;
+}
+
+.note-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  align-items: stretch;
+}
+
+.note-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  width: 100%;
+  text-align: left;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  padding: 0.85rem 1rem;
+  color: inherit;
+  box-shadow: none;
+}
+
+.note-card:hover {
+  background: rgba(79, 70, 229, 0.08);
+}
+
+.note-card.active {
+  border-color: rgba(79, 70, 229, 0.35);
+  background: rgba(79, 70, 229, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.2);
+}
+
+.note-card-title {
+  font-weight: 600;
+  font-size: 0.98rem;
+}
+
+.note-card-meta {
+  font-size: 0.8rem;
   color: var(--muted);
-  margin-top: 2rem;
 }
 
-.cloze {
-  background: rgba(90, 103, 216, 0.15);
-  border-bottom: 2px dashed var(--accent-strong);
-  padding: 0 0.2rem;
+.icon-button {
+  background: transparent;
+  border: 1px solid rgba(31, 42, 68, 0.12);
+  border-radius: 0.8rem;
+  padding: 0.35rem 0.55rem;
+  color: var(--muted);
+  box-shadow: none;
 }
 
-.cloze.needs-review {
-  background: rgba(31, 31, 61, 0.12);
-  border-bottom-style: solid;
-  color: transparent;
+.icon-button:hover {
+  border-color: rgba(239, 68, 68, 0.35);
+  color: #b91c1c;
+  background: rgba(239, 68, 68, 0.08);
 }
 
-.cloze.needs-review::after {
-  content: "[ ... ]";
+.editor-area {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(217, 222, 243, 0.7);
+  box-shadow: var(--card-shadow);
+  padding: 1.75rem;
+  min-height: 540px;
+  display: flex;
+  flex-direction: column;
+}
+
+.editor-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+}
+
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.editor-toolbar {
+  display: inline-flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.editor {
+  border: 1px solid var(--border);
+  border-radius: 1.1rem;
+  padding: 1.25rem;
+  background: white;
+  min-height: 360px;
+  line-height: 1.6;
+  overflow-y: auto;
+  box-shadow: inset 0 1px 2px rgba(31, 42, 68, 0.08);
+}
+
+.editor:focus {
+  outline: 3px solid rgba(79, 70, 229, 0.18);
+}
+
+.empty-state {
+  margin: auto;
+  text-align: center;
+  max-width: 320px;
+  color: var(--muted);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.empty-state h2 {
+  color: var(--fg);
+}
+
+.save-status {
+  font-size: 0.85rem;
+}
+
+.save-status[data-state="dirty"] {
+  color: var(--warning);
+}
+
+.save-status[data-state="saving"] {
   color: var(--accent-strong);
 }
 
-.rating-panel {
-  display: flex;
-  gap: 0.25rem;
-  margin-left: 0.5rem;
-}
-
-.rating-panel button {
-  font-size: 0.75rem;
-  padding: 0.25rem 0.5rem;
-}
-
-.revision {
-  border: 1px solid var(--border);
-  border-radius: 0.75rem;
-  padding: 1rem;
-  background: white;
-  min-height: 320px;
+.save-status[data-state="error"] {
+  color: var(--danger);
 }
 
 .toast {
   position: fixed;
-  bottom: 1.5rem;
-  right: 1.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 0.75rem;
+  bottom: 1.75rem;
+  right: 1.75rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 1rem;
   background: var(--accent);
   color: white;
-  box-shadow: 0 20px 40px -40px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 20px 40px -28px rgba(31, 42, 68, 0.55);
+  font-weight: 500;
+  z-index: 20;
+}
+
+.toast[data-type="error"] {
+  background: var(--danger);
 }
 
 .toast[data-type="success"] {
   background: var(--success);
-}
-
-.toast[data-type="error"] {
-  background: #e53e3e;
 }
 
 .toast[data-type="warning"] {
@@ -376,14 +392,43 @@ main {
   display: none;
 }
 
-@media (max-width: 980px) {
-  main {
-    padding: 1rem;
+@media (max-width: 1080px) {
+  .app-main {
+    padding: 1.5rem;
   }
-  .course-layout {
+
+  .workspace {
     grid-template-columns: 1fr;
   }
-  .sidebar {
-    max-height: none;
+
+  .note-list {
+    min-height: 0;
+    max-height: 320px;
+  }
+
+  .notes-container {
+    max-height: 220px;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .card {
+    margin-top: 2.5rem;
+    padding: 2rem 1.75rem;
+  }
+
+  .editor-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .editor-toolbar {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- replace the multi-écran dashboard with a single workspace regrouping the note list and editor
- redesign the interface with a lighter visual style and inline formatting tools for the contenteditable editor
- simplify Firestore usage around a unique notes collection per user and update the security rules accordingly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4f6428a248333a53f6c28370df0b6