### PR TITLE
Empêcher l'extension involontaire des trous

### DIFF
--- a/app.js
+++ b/app.js
@@ -750,6 +750,11 @@ function bootstrapApp() {
       cloze.dataset.placeholder = generateClozePlaceholder();
     }
     const points = setClozePoints(cloze, getClozePoints(cloze));
+    if (points <= 0) {
+      cloze.setAttribute("contenteditable", "false");
+    } else {
+      cloze.removeAttribute("contenteditable");
+    }
     if (points > 0) {
       cloze.classList.remove("cloze-revealed");
     }
@@ -788,7 +793,10 @@ function bootstrapApp() {
     wrapper.appendChild(fragment);
     range.insertNode(wrapper);
     selection.removeAllRanges();
-    selection.selectAllChildren(wrapper);
+    const afterRange = document.createRange();
+    afterRange.setStartAfter(wrapper);
+    afterRange.collapse(true);
+    selection.addRange(afterRange);
     ui.noteEditor.focus();
     refreshClozeElement(wrapper);
     handleEditorInput();


### PR DESCRIPTION
## Summary
- empêche l'édition directe des trous masqués pour éviter qu'ils ne s'allongent quand on tape du texte
- replace le curseur juste après un nouveau trou pour permettre de continuer la saisie immédiatement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d51554aa5083338d5434628cad7a73