### PR TITLE
Ensure cloze answers stay revealed after positive feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -723,11 +723,21 @@ function bootstrapApp() {
     return normalizeClozePoints(cloze.dataset.points);
   }
 
+  function updateClozeMaskState(cloze, shouldMask) {
+    if (!cloze) return;
+    cloze.classList.remove("cloze-revealed");
+    if (shouldMask) {
+      cloze.classList.add("cloze-masked");
+    } else {
+      cloze.classList.remove("cloze-masked");
+    }
+  }
+
   function setClozePoints(cloze, points) {
     if (!cloze) return 0;
     const normalized = normalizeClozePoints(points);
     cloze.dataset.points = formatClozePoints(normalized);
-    cloze.classList.toggle("cloze-masked", normalized <= 0);
+    updateClozeMaskState(cloze, normalized <= 0);
     updateClozeTooltip(cloze, normalized);
     return normalized;
   }
@@ -754,9 +764,6 @@ function bootstrapApp() {
       cloze.setAttribute("contenteditable", "false");
     } else {
       cloze.removeAttribute("contenteditable");
-    }
-    if (points > 0) {
-      cloze.classList.remove("cloze-revealed");
     }
   }
 


### PR DESCRIPTION
## Summary
- centralize the logic that toggles the cloze masking classes
- make sure positive feedback permanently removes the mask while negative feedback re-applies it

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d516b4439c83338faf351a854f3c31