### PR TITLE
Empêcher le remasquage des clozes après sauvegarde

### DIFF
--- a/app.js
+++ b/app.js
@@ -394,7 +394,7 @@ function bootstrapApp() {
     state.currentNote = { ...state.pendingRemoteNote };
     state.pendingRemoteNote = null;
     state.hasUnsavedChanges = false;
-    applyCurrentNoteToEditor({ force: true });
+    applyCurrentNoteToEditor();
   }
 
   function updateActiveNoteHighlight() {


### PR DESCRIPTION
## Summary
- éviter de forcer le rechargement de la fiche lors de l'application d'une mise à jour distante
- préserver l'état d'affichage manuel des clozes tant qu'une nouvelle itération n'est pas lancée

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d546bc55308333b36bfca746b3f762