### PR TITLE
Refine workspace layout for focus-first experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,19 @@
       </div>
       <div class="header-actions">
         <span id="current-user" class="muted"></span>
-        <button id="logout-btn" class="secondary">Se déconnecter</button>
+        <button
+          type="button"
+          id="workspace-menu-btn"
+          class="header-menu-toggle"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-label="Ouvrir le menu principal"
+        >
+          ⋮
+        </button>
+        <div id="workspace-menu" class="header-menu" role="menu">
+          <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
+        </div>
       </div>
     </header>
 
@@ -51,13 +63,24 @@
 
       <section id="workspace" class="view hidden">
         <div class="workspace">
-          <aside class="note-list">
+          <aside class="note-list" aria-label="Mes fiches">
             <div class="note-list-header">
-              <div>
+              <div class="note-list-title">
                 <h2>Mes fiches</h2>
                 <p class="muted small">Tout est enregistré automatiquement.</p>
               </div>
-              <button id="add-note-btn">Nouvelle fiche</button>
+              <div class="note-list-actions">
+                <button
+                  type="button"
+                  id="toggle-sidebar"
+                  class="icon-button ghost"
+                  aria-expanded="true"
+                  aria-label="Réduire la liste des fiches"
+                >
+                  <span aria-hidden="true">⟷</span>
+                </button>
+                <button id="add-note-btn" type="button">Nouvelle fiche</button>
+              </div>
             </div>
             <div id="notes-container" class="notes-container"></div>
           </aside>
@@ -193,6 +216,36 @@
               </div>
             </div>
           </section>
+        </div>
+        <div id="drawer-overlay" class="drawer-overlay" hidden></div>
+        <div class="floating-actions" aria-live="polite">
+          <button
+            type="button"
+            id="mobile-notes-btn"
+            class="floating-action notes"
+            aria-label="Afficher les fiches"
+            aria-pressed="false"
+          >
+            📑
+          </button>
+          <button
+            type="button"
+            id="toggle-focus-btn"
+            class="floating-action focus"
+            aria-pressed="false"
+          >
+            <span aria-hidden="true">⤢</span>
+            <span class="sr-only">Activer le mode focus</span>
+          </button>
+          <button
+            type="button"
+            id="show-toolbar-btn"
+            class="floating-action toolbar"
+            aria-pressed="false"
+          >
+            A
+            <span class="sr-only">Afficher la barre d'outils</span>
+          </button>
         </div>
       </section>
     </main>

--- a/styles.css
+++ b/styles.css
@@ -1,17 +1,17 @@
 :root {
-  --bg: #f4f7fb;
-  --bg-gradient: radial-gradient(circle at top left, #eef2ff, rgba(238, 242, 255, 0) 45%),
-    radial-gradient(circle at bottom right, #e0f2fe, rgba(224, 242, 254, 0) 40%), #f4f7fb;
-  --fg: #1f2a44;
-  --accent: #4f46e5;
-  --accent-strong: #3730a3;
-  --border: #d9def3;
-  --muted: #6b7280;
+  --bg: #eaf4fb;
+  --bg-gradient: radial-gradient(circle at top left, rgba(90, 155, 216, 0.2), rgba(90, 155, 216, 0) 45%),
+    radial-gradient(circle at bottom right, rgba(124, 207, 169, 0.18), rgba(124, 207, 169, 0) 45%), #eaf4fb;
+  --fg: #1e2a32;
+  --accent: #5a9bd8;
+  --accent-strong: #2f6ca9;
+  --border: rgba(90, 155, 216, 0.35);
+  --muted: #6b7c8f;
   --card: #ffffff;
-  --card-shadow: 0 20px 40px -24px rgba(31, 42, 68, 0.35);
-  --danger: #ef4444;
-  --success: #16a34a;
-  --warning: #f59e0b;
+  --card-shadow: 0 22px 48px -32px rgba(47, 108, 169, 0.45);
+  --danger: #e07c7c;
+  --success: #7ccfa9;
+  --warning: #f6b26b;
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -26,6 +26,34 @@ body {
   color: var(--fg);
   display: flex;
   flex-direction: column;
+}
+
+body.notes-drawer-open {
+  overflow: hidden;
+}
+
+body.focus-mode .app-header {
+  transform: translateY(-120%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+body.focus-mode .app-main {
+  padding-top: 1rem;
+}
+
+body.focus-mode .floating-action.focus {
+  background: var(--accent-strong);
+}
+
+body.focus-mode .workspace {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+body.focus-mode .note-list {
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-2rem);
 }
 
 h1,
@@ -49,19 +77,21 @@ textarea {
 
 button {
   border: none;
-  border-radius: 0.75rem;
-  padding: 0.55rem 1.1rem;
-  background: linear-gradient(135deg, var(--accent), #6366f1);
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  background: var(--accent);
   color: white;
-  font-weight: 500;
+  font-weight: 600;
+  letter-spacing: 0.01em;
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
-  box-shadow: 0 12px 24px -18px rgba(79, 70, 229, 0.7);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 16px 32px -22px rgba(47, 108, 169, 0.6);
 }
 
 button:hover:not(:disabled) {
   transform: translateY(-1px);
-  box-shadow: 0 18px 28px -18px rgba(79, 70, 229, 0.7);
+  background: var(--accent-strong);
+  box-shadow: 0 20px 36px -24px rgba(47, 108, 169, 0.65);
 }
 
 button:active:not(:disabled) {
@@ -73,15 +103,20 @@ button:disabled {
   cursor: not-allowed;
 }
 
+button:focus-visible {
+  outline: 3px solid rgba(90, 155, 216, 0.4);
+  outline-offset: 2px;
+}
+
 button.secondary {
-  background: transparent;
-  color: var(--accent);
-  border: 1px solid var(--accent);
+  background: rgba(90, 155, 216, 0.12);
+  color: var(--accent-strong);
+  border: 1px solid rgba(90, 155, 216, 0.2);
   box-shadow: none;
 }
 
 button.secondary:hover:not(:disabled) {
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(90, 155, 216, 0.18);
 }
 
 button.ghost {
@@ -93,8 +128,8 @@ button.ghost {
 }
 
 button.ghost:hover {
-  background: rgba(79, 70, 229, 0.08);
-  border-color: rgba(79, 70, 229, 0.08);
+  background: rgba(90, 155, 216, 0.12);
+  border-color: rgba(90, 155, 216, 0.18);
 }
 
 input[type="text"] {
@@ -109,35 +144,103 @@ input[type="text"] {
 input[type="text"]:focus {
   outline: none;
   border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+  box-shadow: 0 0 0 3px rgba(90, 155, 216, 0.28);
 }
+
 
 .app-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1.2rem 2.5rem;
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(217, 222, 243, 0.6);
+  gap: 1rem;
+  padding: 0.85rem 1.75rem;
+  background: rgba(255, 255, 255, 0.9);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(90, 155, 216, 0.2);
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 12;
+  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .brand h1 {
-  font-size: 1.6rem;
+  font-size: 1.35rem;
+  font-weight: 600;
 }
 
 .subtitle {
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   color: var(--muted);
-  margin-top: 0.35rem;
+  margin-top: 0.25rem;
+}
+
+.header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  position: relative;
+}
+
+.header-menu-toggle {
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: 999px;
+  background: rgba(90, 155, 216, 0.16);
+  color: var(--accent-strong);
+  font-size: 1.25rem;
+  line-height: 1;
+  display: grid;
+  place-items: center;
+  box-shadow: none;
+}
+
+.header-menu-toggle:hover {
+  background: rgba(90, 155, 216, 0.24);
+}
+
+.header-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--card);
+  border-radius: 0.9rem;
+  border: 1px solid rgba(90, 155, 216, 0.2);
+  box-shadow: var(--card-shadow);
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  min-width: 180px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 20;
+}
+
+.header-menu.open {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.header-menu .menu-item {
+  justify-content: flex-start;
+  border-radius: 0.65rem;
+  padding: 0.6rem 0.8rem;
+  font-weight: 500;
+  background: transparent;
+  color: var(--fg);
+  box-shadow: none;
+}
+
+.header-menu .menu-item:hover {
+  background: rgba(90, 155, 216, 0.12);
+  color: var(--accent-strong);
 }
 
 .app-main {
   flex: 1;
-  padding: 2rem 2.5rem 3rem;
+  padding: 1.5rem 1.75rem 2.5rem;
 }
 
 .view {
@@ -200,20 +303,32 @@ input[type="text"]:focus {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(260px, 320px) 1fr;
-  gap: 2rem;
+  grid-template-columns: minmax(220px, 24%) minmax(0, 1fr);
+  gap: 1.5rem;
   align-items: stretch;
+  transition: grid-template-columns 0.3s ease;
+}
+
+.workspace.sidebar-collapsed {
+  grid-template-columns: minmax(0, 0) minmax(0, 1fr);
 }
 
 .note-list {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 1.5rem;
-  border: 1px solid rgba(217, 222, 243, 0.7);
+  background: #eaf4fb;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(90, 155, 216, 0.25);
   box-shadow: var(--card-shadow);
-  padding: 1.5rem;
+  padding: 1.35rem;
   display: flex;
   flex-direction: column;
   min-height: 540px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.workspace.sidebar-collapsed .note-list {
+  opacity: 0;
+  transform: translateX(-1.5rem);
+  pointer-events: none;
 }
 
 .note-list-header {
@@ -221,6 +336,17 @@ input[type="text"]:focus {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
+}
+
+.note-list-title h2 {
+  font-size: 1.1rem;
+}
+
+.note-list-actions {
+  display: inline-flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .notes-container {
@@ -238,7 +364,7 @@ input[type="text"]:focus {
 }
 
 .notes-container::-webkit-scrollbar-thumb {
-  background: rgba(79, 70, 229, 0.25);
+  background: rgba(90, 155, 216, 0.3);
   border-radius: 3px;
 }
 
@@ -256,22 +382,22 @@ input[type="text"]:focus {
   gap: 0.35rem;
   width: 100%;
   text-align: left;
-  background: rgba(255, 255, 255, 0.7);
+  background: rgba(255, 255, 255, 0.85);
   border: 1px solid transparent;
-  border-radius: 1rem;
+  border-radius: 0.95rem;
   padding: 0.85rem 1rem;
   color: inherit;
   box-shadow: none;
 }
 
 .note-card:hover {
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(90, 155, 216, 0.12);
 }
 
 .note-card.active {
-  border-color: rgba(79, 70, 229, 0.35);
-  background: rgba(79, 70, 229, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.2);
+  border-color: rgba(90, 155, 216, 0.4);
+  background: rgba(90, 155, 216, 0.18);
+  box-shadow: inset 0 0 0 1px rgba(90, 155, 216, 0.22);
 }
 
 .note-card-title {
@@ -285,29 +411,29 @@ input[type="text"]:focus {
 }
 
 .icon-button {
-  background: transparent;
-  border: 1px solid rgba(31, 42, 68, 0.12);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(90, 155, 216, 0.2);
   border-radius: 0.8rem;
   padding: 0.35rem 0.55rem;
-  color: var(--muted);
+  color: var(--accent-strong);
   box-shadow: none;
 }
 
 .icon-button:hover {
-  border-color: rgba(239, 68, 68, 0.35);
-  color: #b91c1c;
-  background: rgba(239, 68, 68, 0.08);
+  border-color: rgba(90, 155, 216, 0.4);
+  background: rgba(255, 255, 255, 0.9);
 }
 
 .editor-area {
-  background: rgba(255, 255, 255, 0.95);
-  border-radius: 1.5rem;
-  border: 1px solid rgba(217, 222, 243, 0.7);
+  background: var(--card);
+  border-radius: 1.35rem;
+  border: 1px solid rgba(90, 155, 216, 0.25);
   box-shadow: var(--card-shadow);
-  padding: 1.75rem;
+  padding: 2rem 2.25rem 2.5rem;
   min-height: 540px;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .editor-wrapper {
@@ -316,6 +442,7 @@ input[type="text"]:focus {
   gap: 1rem;
   height: 100%;
   position: relative;
+  padding-top: 4.5rem;
 }
 
 .editor-header {
@@ -326,24 +453,43 @@ input[type="text"]:focus {
 }
 
 .editor-toolbar {
+  position: absolute;
+  top: 1.1rem;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.65rem 0.85rem;
-  background: #f8f9fb;
-  border-radius: 0.9rem;
-  border: 1px solid #dfe1eb;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  gap: 0.75rem;
+  padding: 0.45rem 0.85rem;
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.75rem;
+  border: 1px solid rgba(90, 155, 216, 0.25);
+  box-shadow: var(--card-shadow);
+  backdrop-filter: blur(10px);
+  max-width: calc(100% - 3rem);
+  overflow-x: auto;
+  scrollbar-width: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 2;
+}
+
+.editor-toolbar::-webkit-scrollbar {
+  display: none;
+}
+
+body.show-toolbar .editor-toolbar {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateX(-50%);
 }
 
 .toolbar-group {
   display: flex;
   align-items: center;
   gap: 0.35rem;
-  padding-right: 0.75rem;
-  margin-right: 0.75rem;
-  border-right: 1px solid #e4e6ef;
+  padding-right: 0.6rem;
+  margin-right: 0.6rem;
+  border-right: 1px solid rgba(90, 155, 216, 0.2);
 }
 
 .toolbar-group:last-child {
@@ -361,7 +507,7 @@ input[type="text"]:focus {
   display: inline-flex;
   align-items: center;
   background: white;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgba(90, 155, 216, 0.3);
   border-radius: 0.5rem;
   padding: 0 0.45rem;
   min-width: 130px;
@@ -373,7 +519,7 @@ input[type="text"]:focus {
   position: absolute;
   right: 0.6rem;
   font-size: 0.75rem;
-  color: #6b7280;
+  color: var(--muted);
   pointer-events: none;
 }
 
@@ -396,7 +542,7 @@ input[type="text"]:focus {
   align-items: center;
   gap: 0.3rem;
   background: white;
-  border: 1px solid #d1d5db;
+  border: 1px solid rgba(90, 155, 216, 0.3);
   border-radius: 0.5rem;
   padding: 0.2rem 0.35rem;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.85);
@@ -427,12 +573,12 @@ input[type="text"]:focus {
 }
 
 .editor-toolbar .toolbar-button:hover {
-  background: #eef1ff;
-  border-color: rgba(79, 70, 229, 0.35);
+  background: rgba(90, 155, 216, 0.15);
+  border-color: rgba(90, 155, 216, 0.35);
 }
 
 .editor-toolbar .toolbar-button:active {
-  background: #e0e7ff;
+  background: rgba(90, 155, 216, 0.25);
 }
 
 .editor-toolbar .toolbar-button .icon {
@@ -446,13 +592,13 @@ input[type="text"]:focus {
   padding: 0.3rem 0.95rem;
   font-weight: 600;
   color: var(--accent-strong);
-  border-color: rgba(79, 70, 229, 0.35);
-  background: rgba(79, 70, 229, 0.08);
+  border-color: rgba(90, 155, 216, 0.35);
+  background: rgba(90, 155, 216, 0.12);
 }
 
 .editor-toolbar .iteration-button:hover {
-  background: rgba(79, 70, 229, 0.18);
-  border-color: rgba(79, 70, 229, 0.55);
+  background: rgba(90, 155, 216, 0.2);
+  border-color: rgba(90, 155, 216, 0.55);
   color: var(--accent-strong);
 }
 
@@ -489,10 +635,10 @@ input[type="text"]:focus {
 }
 
 .editor-toolbar .toolbar-toggle[aria-pressed="true"] {
-  background: #e0e7ff;
-  border-color: rgba(79, 70, 229, 0.55);
+  background: rgba(90, 155, 216, 0.22);
+  border-color: rgba(90, 155, 216, 0.55);
   color: var(--accent-strong);
-  box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.18) inset;
+  box-shadow: 0 0 0 2px rgba(90, 155, 216, 0.2) inset;
 }
 
 .font-size-control .toolbar-button {
@@ -512,7 +658,7 @@ input[type="text"]:focus {
 }
 
 .editor:focus {
-  outline: 3px solid rgba(79, 70, 229, 0.18);
+  outline: 3px solid rgba(90, 155, 216, 0.28);
 }
 
 .editor h2 {
@@ -525,8 +671,8 @@ input[type="text"]:focus {
 .editor blockquote {
   margin: 1rem 0;
   padding: 0.85rem 1rem;
-  border-left: 4px solid rgba(79, 70, 229, 0.55);
-  background: rgba(79, 70, 229, 0.08);
+  border-left: 4px solid rgba(90, 155, 216, 0.55);
+  background: rgba(90, 155, 216, 0.12);
   border-radius: 0.9rem;
 }
 
@@ -543,12 +689,12 @@ input[type="text"]:focus {
 }
 
 .editor .cloze {
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.18), rgba(14, 165, 233, 0.16));
+  background: linear-gradient(135deg, rgba(90, 155, 216, 0.22), rgba(124, 207, 169, 0.2));
   color: var(--accent-strong);
   padding: 0.12rem 0.45rem;
   border-radius: 0.6rem;
   font-weight: 600;
-  border-bottom: 2px solid rgba(79, 70, 229, 0.45);
+  border-bottom: 2px solid rgba(47, 108, 169, 0.45);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -562,15 +708,15 @@ input[type="text"]:focus {
 }
 
 .editor .cloze:hover {
-  background: linear-gradient(135deg, rgba(79, 70, 229, 0.24), rgba(14, 165, 233, 0.22));
-  box-shadow: 0 6px 18px -12px rgba(79, 70, 229, 0.55);
+  background: linear-gradient(135deg, rgba(90, 155, 216, 0.28), rgba(124, 207, 169, 0.26));
+  box-shadow: 0 6px 18px -12px rgba(47, 108, 169, 0.45);
 }
 
 .editor .cloze.cloze-masked {
   color: transparent;
   position: relative;
-  background: rgba(148, 163, 184, 0.18);
-  border-bottom-color: rgba(148, 163, 184, 0.8);
+  background: rgba(107, 124, 143, 0.16);
+  border-bottom-color: rgba(107, 124, 143, 0.65);
 }
 
 .editor .cloze.cloze-masked::after {
@@ -583,14 +729,14 @@ input[type="text"]:focus {
 }
 
 .editor .cloze.cloze-masked:hover {
-  background: rgba(79, 70, 229, 0.2);
-  border-bottom-color: rgba(79, 70, 229, 0.55);
+  background: rgba(90, 155, 216, 0.2);
+  border-bottom-color: rgba(90, 155, 216, 0.55);
 }
 
 .editor .cloze.cloze-masked.cloze-revealed {
   color: var(--fg);
   background: #fff7ed;
-  border-bottom-color: rgba(79, 70, 229, 0.65);
+  border-bottom-color: rgba(90, 155, 216, 0.55);
 }
 
 .editor .cloze.cloze-masked.cloze-revealed::after {
@@ -648,8 +794,8 @@ input[type="text"]:focus {
 }
 
 .cloze-feedback button:hover {
-  background: #e0e7ff;
-  border-color: rgba(79, 70, 229, 0.4);
+  background: rgba(90, 155, 216, 0.18);
+  border-color: rgba(90, 155, 216, 0.4);
 }
 
 .cloze-feedback button span {
@@ -717,55 +863,192 @@ input[type="text"]:focus {
   display: none;
 }
 
-@media (max-width: 1080px) {
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(30, 42, 50, 0.25);
+  backdrop-filter: blur(3px);
+  z-index: 22;
+  transition: opacity 0.2s ease;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.drawer-overlay[hidden] {
+  display: none;
+}
+
+body.notes-drawer-open .drawer-overlay {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.floating-actions {
+  position: fixed;
+  right: 1.1rem;
+  bottom: 1.1rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 26;
+  pointer-events: none;
+}
+
+.floating-action {
+  pointer-events: auto;
+  width: 3rem;
+  height: 3rem;
+  padding: 0;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 1.2rem;
+  background: var(--accent);
+  color: white;
+  border: none;
+  box-shadow: 0 18px 32px -22px rgba(47, 108, 169, 0.58);
+}
+
+.floating-action:hover {
+  background: var(--accent-strong);
+}
+
+.floating-action.notes {
+  font-size: 1.4rem;
+}
+
+.floating-action.focus {
+  font-size: 1.15rem;
+}
+
+.floating-action.toolbar {
+  font-weight: 700;
+}
+
+.floating-action[aria-pressed="true"] {
+  background: var(--accent-strong);
+}
+
+@media (max-width: 1180px) {
   .app-main {
-    padding: 1.5rem;
+    padding: 1.25rem 1.35rem 2rem;
   }
 
   .workspace {
-    grid-template-columns: 1fr;
-  }
-
-  .note-list {
-    min-height: 0;
-    max-height: 320px;
-  }
-
-  .notes-container {
-    max-height: 220px;
+    gap: 1.25rem;
   }
 }
 
-@media (max-width: 640px) {
+@media (max-width: 900px) {
   .app-header {
-    flex-direction: column;
-    align-items: flex-start;
+    padding: 0.75rem 1.1rem;
+  }
+
+  .brand h1 {
+    font-size: 1.2rem;
+  }
+
+  .subtitle {
+    font-size: 0.85rem;
+  }
+
+  .workspace {
+    grid-template-columns: minmax(0, 1fr);
     gap: 1rem;
   }
 
-  .card {
-    margin-top: 2.5rem;
-    padding: 2rem 1.75rem;
+  .workspace.sidebar-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .note-list {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: min(320px, 82vw);
+    max-width: 360px;
+    min-height: 100vh;
+    max-height: none;
+    border-radius: 0 1.35rem 1.35rem 0;
+    transform: translateX(-110%);
+    opacity: 1;
+    padding: 1.75rem 1.35rem 2.5rem;
+    z-index: 25;
+    box-shadow: var(--card-shadow);
+  }
+
+  .note-list-actions {
+    flex-direction: row;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  #toggle-sidebar {
+    display: none;
+  }
+
+  body.notes-drawer-open .note-list {
+    transform: translateX(0);
+  }
+
+  .workspace.sidebar-collapsed .note-list {
+    transform: translateX(-110%);
+  }
+
+  .notes-container {
+    max-height: calc(100vh - 220px);
+  }
+
+  .floating-actions {
+    display: flex;
+  }
+
+  .editor-area {
+    padding: 1.5rem 1.25rem 2.25rem;
+    border-radius: 1.1rem;
+  }
+
+  .editor-wrapper {
+    padding-top: 3.6rem;
+  }
+
+  .editor-toolbar {
+    top: 0.6rem;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -0.6rem) scale(0.96);
+  }
+
+  body.show-toolbar .editor-toolbar {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(-50%, 0);
   }
 
   .editor-header {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .editor-toolbar {
-    width: 100%;
+    gap: 0.6rem;
   }
 
   .toolbar-group {
     border-right: none;
     margin-right: 0;
     padding-right: 0;
-    width: 100%;
-  }
-
-  .toolbar-group--primary {
-    flex-wrap: wrap;
-    row-gap: 0.4rem;
   }
 }
+
+@media (max-width: 560px) {
+  .app-main {
+    padding: 1rem 1rem 1.75rem;
+  }
+
+  .card {
+    margin-top: 1.5rem;
+    padding: 1.75rem 1.5rem;
+  }
+
+  .brand .subtitle {
+    display: none;
+  }
+}
+


### PR DESCRIPTION
## Summary
- restyle the workspace with a pastel blue palette, slimmer header, and collapsible note sidebar
- move the editor toolbar to a floating control with mobile toggle and add mobile drawer/focus actions
- enhance layout scripting to handle sidebar collapsing, drawer overlay, focus mode, and header menu

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d54f9cf72c833391a03f792893d1d7