### PR TITLE
Improve cloze feedback styling and mobile layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -129,6 +129,19 @@ function bootstrapApp() {
       toastType: "error"
     }
   };
+  const CLOZE_FEEDBACK_STATUS_DATASET_KEY = "feedbackStatus";
+  const CLOZE_FEEDBACK_STATUS_CLASSES = {
+    yes: "cloze-status-positive",
+    "rather-yes": "cloze-status-positive",
+    neutral: "cloze-status-neutral",
+    "rather-no": "cloze-status-negative",
+    no: "cloze-status-negative"
+  };
+  const CLOZE_STATUS_CLASS_VALUES = [
+    "cloze-status-positive",
+    "cloze-status-neutral",
+    "cloze-status-negative"
+  ];
   const CLOZE_DEFER_DATA_KEY = "deferMask";
   const CLOZE_MANUAL_REVEAL_SET_KEY = "revealedClozes";
   const CLOZE_MANUAL_REVEAL_DATASET_KEY = "manualReveal";
@@ -300,6 +313,7 @@ function bootstrapApp() {
       setToolbarVisibility(false);
       if (!document.body.classList.contains("focus-mode") && ui.focusToggle) {
         ui.focusToggle.setAttribute("aria-pressed", "false");
+        ui.focusToggle.setAttribute("aria-label", "Activer le mode focus");
         const focusLabel = ui.focusToggle.querySelector(".sr-only");
         if (focusLabel) {
           focusLabel.textContent = "Activer le mode focus";
@@ -315,6 +329,7 @@ function bootstrapApp() {
       setNotesDrawer(false);
       if (!document.body.classList.contains("show-toolbar") && ui.toolbarToggle) {
         ui.toolbarToggle.setAttribute("aria-pressed", "false");
+        ui.toolbarToggle.setAttribute("aria-label", "Afficher la barre d'outils");
         const toolbarLabel = ui.toolbarToggle.querySelector(".sr-only");
         if (toolbarLabel) {
           toolbarLabel.textContent = "Afficher la barre d'outils";
@@ -374,6 +389,10 @@ function bootstrapApp() {
           ? "Désactiver le mode focus"
           : "Activer le mode focus";
       }
+      ui.focusToggle.setAttribute(
+        "aria-label",
+        shouldEnable ? "Désactiver le mode focus" : "Activer le mode focus"
+      );
       const icon = ui.focusToggle.querySelector("[aria-hidden='true']");
       if (icon) {
         icon.textContent = shouldEnable ? "⤡" : "⤢";
@@ -396,6 +415,10 @@ function bootstrapApp() {
           ? "Masquer la barre d'outils"
           : "Afficher la barre d'outils";
       }
+      ui.toolbarToggle.setAttribute(
+        "aria-label",
+        shouldShow ? "Masquer la barre d'outils" : "Afficher la barre d'outils"
+      );
     }
   }
 
@@ -1050,6 +1073,19 @@ function bootstrapApp() {
     }
   }
 
+  function updateClozeFeedbackStyle(cloze) {
+    if (!cloze) return;
+    CLOZE_STATUS_CLASS_VALUES.forEach((className) => {
+      cloze.classList.remove(className);
+    });
+    const status = cloze.dataset[CLOZE_FEEDBACK_STATUS_DATASET_KEY];
+    if (!status) return;
+    const className = CLOZE_FEEDBACK_STATUS_CLASSES[status];
+    if (className) {
+      cloze.classList.add(className);
+    }
+  }
+
   function refreshClozeElement(cloze) {
     if (!cloze) return;
     if (!cloze.dataset.placeholder) {
@@ -1061,6 +1097,7 @@ function bootstrapApp() {
     } else {
       cloze.removeAttribute("contenteditable");
     }
+    updateClozeFeedbackStyle(cloze);
   }
 
   function refreshAllClozes() {
@@ -1125,6 +1162,10 @@ function bootstrapApp() {
 
     clozes.forEach((cloze) => {
       delete cloze.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY];
+      if (cloze.dataset[CLOZE_FEEDBACK_STATUS_DATASET_KEY]) {
+        delete cloze.dataset[CLOZE_FEEDBACK_STATUS_DATASET_KEY];
+      }
+      updateClozeFeedbackStyle(cloze);
       const hadDeferred = cloze.dataset[CLOZE_DEFER_DATA_KEY] === "1";
       if (hadDeferred) {
         delete cloze.dataset[CLOZE_DEFER_DATA_KEY];
@@ -1301,6 +1342,11 @@ function bootstrapApp() {
     const newPoints = feedback.reset ? 0 : currentPoints + (feedback.delta || 0);
     if (feedback.reset && cloze.dataset[CLOZE_DEFER_DATA_KEY]) {
       delete cloze.dataset[CLOZE_DEFER_DATA_KEY];
+    }
+    if (feedbackKey && CLOZE_FEEDBACK_STATUS_CLASSES[feedbackKey]) {
+      cloze.dataset[CLOZE_FEEDBACK_STATUS_DATASET_KEY] = feedbackKey;
+    } else {
+      delete cloze.dataset[CLOZE_FEEDBACK_STATUS_DATASET_KEY];
     }
     const appliedPoints = setClozePoints(cloze, newPoints);
     refreshClozeElement(cloze);

--- a/index.html
+++ b/index.html
@@ -104,13 +104,37 @@
 
             <div id="editor-wrapper" class="editor-wrapper hidden" aria-live="polite">
               <div class="editor-header">
-                <input
-                  id="note-title"
-                  type="text"
-                  placeholder="Titre de la fiche"
-                  aria-label="Titre de la fiche"
-                />
-                <span id="save-status" class="save-status muted"></span>
+                <div class="editor-header-main">
+                  <input
+                    id="note-title"
+                    type="text"
+                    placeholder="Titre de la fiche"
+                    aria-label="Titre de la fiche"
+                  />
+                  <span id="save-status" class="save-status muted"></span>
+                </div>
+                <div class="editor-header-actions">
+                  <button
+                    type="button"
+                    id="toggle-focus-btn"
+                    class="icon-button ghost"
+                    aria-pressed="false"
+                    aria-label="Activer le mode focus"
+                  >
+                    <span aria-hidden="true">⤢</span>
+                    <span class="sr-only">Activer le mode focus</span>
+                  </button>
+                  <button
+                    type="button"
+                    id="show-toolbar-btn"
+                    class="icon-button ghost mobile-only"
+                    aria-pressed="false"
+                    aria-label="Afficher la barre d'outils"
+                  >
+                    <span aria-hidden="true">☰</span>
+                    <span class="sr-only">Afficher la barre d'outils</span>
+                  </button>
+                </div>
               </div>
               <div class="editor-toolbar" aria-label="Outils de mise en forme">
                 <div class="toolbar-group toolbar-group--primary">

--- a/styles.css
+++ b/styles.css
@@ -467,6 +467,12 @@ input[type="text"]:focus {
   color: var(--accent-strong);
 }
 
+.icon-button[aria-pressed="true"] {
+  background: rgba(26, 115, 232, 0.18);
+  border-color: rgba(26, 115, 232, 0.45);
+  color: var(--accent-strong);
+}
+
 .editor-area {
   background: transparent;
   border-radius: 0;
@@ -483,6 +489,7 @@ input[type="text"]:focus {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  flex: 1 1 auto;
   height: 100%;
   position: relative;
   max-width: 860px;
@@ -495,6 +502,33 @@ input[type="text"]:focus {
   justify-content: space-between;
   gap: 1rem;
   align-items: center;
+}
+
+.editor-header-main {
+  flex: 1 1 auto;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.editor-header-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.editor-header-actions .icon-button {
+  padding: 0.35rem 0.55rem;
+}
+
+.editor-header-main .save-status {
+  justify-self: end;
+}
+
+.editor-header-actions .icon-button span[aria-hidden="true"] {
+  font-size: 1.1rem;
+  line-height: 1;
 }
 
 .editor-toolbar {
@@ -747,12 +781,35 @@ input[type="text"]:focus {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  transition: background 0.2s ease, color 0.2s ease;
-  box-shadow: none;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.22);
 }
 
 .editor .cloze:not(.cloze-masked) {
   cursor: text;
+  color: var(--fg);
+  background: rgba(26, 115, 232, 0.12);
+  border-bottom-color: rgba(26, 115, 232, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.28);
+}
+
+.editor .cloze:not(.cloze-masked).cloze-status-positive {
+  background: rgba(24, 128, 56, 0.18);
+  border-bottom-color: rgba(24, 128, 56, 0.48);
+  box-shadow: inset 0 0 0 1px rgba(24, 128, 56, 0.45);
+}
+
+.editor .cloze:not(.cloze-masked).cloze-status-neutral {
+  background: rgba(249, 171, 0, 0.22);
+  border-bottom-color: rgba(249, 171, 0, 0.5);
+  box-shadow: inset 0 0 0 1px rgba(249, 171, 0, 0.55);
+}
+
+.editor .cloze:not(.cloze-masked).cloze-status-negative {
+  background: rgba(217, 48, 37, 0.2);
+  border-bottom-color: rgba(217, 48, 37, 0.55);
+  box-shadow: inset 0 0 0 1px rgba(217, 48, 37, 0.55);
 }
 
 .editor .cloze:hover {
@@ -764,6 +821,7 @@ input[type="text"]:focus {
   position: relative;
   background: rgba(95, 99, 104, 0.16);
   border-bottom-color: rgba(95, 99, 104, 0.45);
+  box-shadow: none;
 }
 
 .editor .cloze.cloze-masked::after {
@@ -1013,6 +1071,7 @@ body.notes-drawer-open .drawer-overlay {
 
   .editor-area {
     padding: 1rem 1rem 1.75rem;
+    min-height: calc(100vh - var(--header-height) - 2.5rem);
   }
 
   .editor-toolbar {
@@ -1056,6 +1115,36 @@ body.notes-drawer-open .drawer-overlay {
   .editor {
     padding: 1.75rem 1.5rem;
     border-radius: 0.4rem;
+    min-height: calc(100vh - var(--header-height) - 6.5rem);
+  }
+
+  .editor-header {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .editor-header-main {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .editor-header-main .save-status {
+    align-self: flex-start;
+  }
+
+  .editor-header-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+
+  body:not(.show-toolbar) .editor-toolbar {
+    display: none;
+  }
+
+  .editor-wrapper {
+    max-width: none;
   }
 }
 
@@ -1073,8 +1162,14 @@ body.notes-drawer-open .drawer-overlay {
     display: none;
   }
 
+  .editor-area {
+    padding: 0.75rem 0.85rem 1.5rem;
+    min-height: calc(100vh - var(--header-height) - 1.5rem);
+  }
+
   .editor {
-    padding: 1.5rem 1.25rem;
+    padding: 1.4rem 1.1rem;
+    min-height: calc(100vh - var(--header-height) - 5.5rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep revealed cloze text visible while adding color-coded feedback states that persist until a new iteration
- expose focus and toolbar toggle controls and update accessibility labels for the new layout
- refine responsive styles so the editor area dominates on mobile and the toolbar can be collapsed to save space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d588730448833386b690a67ffc51cc