### PR TITLE
Fix cloze reveal persistence and add sidebar restore button

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#1d4ed8" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#grad)" />
+  <path
+    d="M32 14c-6.9 0-12 4.25-12 10.74 0 4.46 2.54 7.68 6.52 9.23l-5.28 15.94h7l3.3-10.32h1.92l3.3 10.32h6.98l-5.24-15.82c4.1-1.5 6.5-4.8 6.5-9.35C44 18.1 38.94 14 32 14zm0 6c3.26 0 5.5 1.92 5.5 4.88 0 2.9-2.24 4.82-5.5 4.82s-5.5-1.92-5.5-4.82C26.5 21.92 28.74 20 32 20z"
+    fill="#f8fafc"
+  />
+</svg>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Apprentissage actif</title>
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -123,6 +124,17 @@
                   >
                     <span aria-hidden="true">⤢</span>
                     <span class="sr-only">Activer le mode focus</span>
+                  </button>
+                  <button
+                    type="button"
+                    id="restore-sidebar-btn"
+                    class="icon-button ghost"
+                    aria-label="Afficher la liste des fiches"
+                    aria-hidden="true"
+                    hidden
+                  >
+                    <span aria-hidden="true">☰</span>
+                    <span class="sr-only">Afficher la liste des fiches</span>
                   </button>
                   <button
                     type="button"

--- a/styles.css
+++ b/styles.css
@@ -518,6 +518,10 @@ input[type="text"]:focus {
   gap: 0.4rem;
 }
 
+#restore-sidebar-btn {
+  display: inline-flex;
+}
+
 .editor-header-actions .icon-button {
   padding: 0.35rem 0.55rem;
 }
@@ -1051,6 +1055,10 @@ body.notes-drawer-open .drawer-overlay {
     flex-direction: row;
     align-items: center;
     gap: 0.6rem;
+  }
+
+  #restore-sidebar-btn {
+    display: none !important;
   }
 
   #toggle-sidebar {


### PR DESCRIPTION
## Summary
- preserve manual reveal state for clozes so answers stay visible until the next iteration
- add a helper and refresh logic to keep revealed clozes tracked even after reloads
- introduce a restore button to reopen the collapsed sidebar and add a custom favicon

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d58eda52008333b1423a7152d10c41