### PR TITLE
Make header hamburger control sidebar and improve mobile toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,11 +19,13 @@
         <button
           type="button"
           id="mobile-notes-btn"
-          class="header-icon-button mobile-only"
+          class="header-icon-button"
           aria-label="Afficher les fiches"
           aria-pressed="false"
+          aria-expanded="true"
         >
           ☰
+          <span class="sr-only">Afficher les fiches</span>
         </button>
         <div class="brand-text">
           <h1>Apprentissage actif</h1>
@@ -82,15 +84,6 @@
                 <p class="muted small">Tout est enregistré automatiquement.</p>
               </div>
               <div class="note-list-actions">
-                <button
-                  type="button"
-                  id="toggle-sidebar"
-                  class="icon-button ghost"
-                  aria-expanded="true"
-                  aria-label="Réduire la liste des fiches"
-                >
-                  <span aria-hidden="true">⟷</span>
-                </button>
                 <button id="add-note-btn" type="button">Nouvelle fiche</button>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1061,10 +1061,6 @@ body.notes-drawer-open .drawer-overlay {
     display: none !important;
   }
 
-  #toggle-sidebar {
-    display: none;
-  }
-
   body.notes-drawer-open .note-list {
     transform: translateX(0);
   }
@@ -1089,6 +1085,22 @@ body.notes-drawer-open .drawer-overlay {
     border-radius: 0.65rem;
     box-shadow: 0 1px 3px rgba(60, 64, 67, 0.16);
     justify-content: flex-start;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    padding: 0.5rem 0.6rem;
+    gap: 0.6rem;
+  }
+
+  .editor-toolbar::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .editor-toolbar::-webkit-scrollbar-thumb {
+    background: rgba(95, 99, 104, 0.35);
+    border-radius: 999px;
   }
 
   .editor-header {
@@ -1098,26 +1110,39 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-group {
-    border-right: none;
-    margin-right: 0;
-    padding-right: 0;
-    width: 100%;
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 0.4rem;
+    border-right: 1px solid var(--border);
+    margin-right: 0.65rem;
+    padding-right: 0.65rem;
+    width: auto;
+    border-bottom: none;
+    padding-bottom: 0;
+    flex: 0 0 auto;
+    flex-wrap: nowrap;
+    white-space: nowrap;
   }
 
   .toolbar-group:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
+    border-right: none;
+    margin-right: 0;
+    padding-right: 0;
   }
 
   .toolbar-group--primary {
-    flex-basis: 100%;
+    flex-basis: auto;
+    min-width: 280px;
   }
 
   .toolbar-group--primary > .toolbar-select,
   .toolbar-group--primary > .font-size-control {
-    flex: 1 1 100%;
+    flex: 1 1 140px;
+  }
+
+  .toolbar-select {
+    min-width: 130px;
+  }
+
+  .font-size-control {
+    flex: 0 0 auto;
   }
 
   .editor {
@@ -1173,6 +1198,19 @@ body.notes-drawer-open .drawer-overlay {
   .editor-area {
     padding: 0.75rem 0.85rem 1.5rem;
     min-height: calc(100vh - var(--header-height) - 1.5rem);
+  }
+
+  .editor-toolbar {
+    padding: 0.45rem 0.5rem;
+    gap: 0.5rem;
+  }
+
+  .toolbar-group--primary {
+    min-width: 240px;
+  }
+
+  .toolbar-select {
+    min-width: 120px;
   }
 
   .editor {


### PR DESCRIPTION
## Summary
- repurpose the header hamburger button to toggle the notes sidebar on desktop and the drawer on mobile while removing the obsolete sidebar toggle button
- guard event delegation helpers against text node targets to make cloze feedback selections reliable
- tighten the editor toolbar layout on small screens so it stays compact and horizontally scrollable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d594cae4788333b47d10aaed9f98a5