### PR TITLE
Supprimer les boutons inutiles et rendre l'en-tête non fixe

### DIFF
--- a/app.js
+++ b/app.js
@@ -210,9 +210,7 @@ function bootstrapApp() {
     clozeFeedback: document.getElementById("cloze-feedback"),
     sidebarRestore: document.getElementById("restore-sidebar-btn"),
     workspaceOverlay: document.getElementById("drawer-overlay"),
-    mobileNotesBtn: document.getElementById("mobile-notes-btn"),
-    focusToggle: document.getElementById("toggle-focus-btn"),
-    toolbarToggle: document.getElementById("show-toolbar-btn")
+    mobileNotesBtn: document.getElementById("mobile-notes-btn")
   };
 
   const workspaceLayout = document.querySelector(".workspace");
@@ -324,20 +322,6 @@ function bootstrapApp() {
       ui.workspaceOverlay.addEventListener("click", () => setNotesDrawer(false));
     }
 
-    if (ui.focusToggle) {
-      ui.focusToggle.addEventListener("click", () => {
-        const enabled = !document.body.classList.contains("focus-mode");
-        setFocusMode(enabled);
-      });
-    }
-
-    if (ui.toolbarToggle) {
-      ui.toolbarToggle.addEventListener("click", () => {
-        const visible = !document.body.classList.contains("show-toolbar");
-        setToolbarVisibility(visible);
-      });
-    }
-
     document.addEventListener("keydown", (event) => {
       if (event.key !== "Escape") return;
       if (document.body.classList.contains("notes-drawer-open")) {
@@ -347,9 +331,6 @@ function bootstrapApp() {
       if (ui.headerMenu && ui.headerMenu.classList.contains("open")) {
         closeHeaderMenu();
       }
-      if (document.body.classList.contains("show-toolbar")) {
-        setToolbarVisibility(false);
-      }
     });
   }
 
@@ -358,33 +339,12 @@ function bootstrapApp() {
 
     if (!isMobile) {
       setNotesDrawer(false);
-      setToolbarVisibility(false);
-      if (!document.body.classList.contains("focus-mode") && ui.focusToggle) {
-        ui.focusToggle.setAttribute("aria-pressed", "false");
-        ui.focusToggle.setAttribute("aria-label", "Activer le mode focus");
-        const focusLabel = ui.focusToggle.querySelector(".sr-only");
-        if (focusLabel) {
-          focusLabel.textContent = "Activer le mode focus";
-        }
-        const focusIcon = ui.focusToggle.querySelector("[aria-hidden='true']");
-        if (focusIcon) {
-          focusIcon.textContent = "⤢";
-        }
-      }
       setSidebarCollapsed(false);
       updateNotesButtonForSidebar(true);
       closeHeaderMenu();
     } else {
       setNotesDrawer(false);
       updateNotesButtonForDrawer(false);
-      if (!document.body.classList.contains("show-toolbar") && ui.toolbarToggle) {
-        ui.toolbarToggle.setAttribute("aria-pressed", "false");
-        ui.toolbarToggle.setAttribute("aria-label", "Afficher la barre d'outils");
-        const toolbarLabel = ui.toolbarToggle.querySelector(".sr-only");
-        if (toolbarLabel) {
-          toolbarLabel.textContent = "Afficher la barre d'outils";
-        }
-      }
     }
   }
 
@@ -418,50 +378,6 @@ function bootstrapApp() {
     }
     if (shouldOpen) {
       closeHeaderMenu();
-    }
-  }
-
-  function setFocusMode(enabled) {
-    const shouldEnable = Boolean(enabled);
-    document.body.classList.toggle("focus-mode", shouldEnable);
-    if (ui.focusToggle) {
-      ui.focusToggle.setAttribute("aria-pressed", String(shouldEnable));
-      const label = ui.focusToggle.querySelector(".sr-only");
-      if (label) {
-        label.textContent = shouldEnable
-          ? "Désactiver le mode focus"
-          : "Activer le mode focus";
-      }
-      ui.focusToggle.setAttribute(
-        "aria-label",
-        shouldEnable ? "Désactiver le mode focus" : "Activer le mode focus"
-      );
-      const icon = ui.focusToggle.querySelector("[aria-hidden='true']");
-      if (icon) {
-        icon.textContent = shouldEnable ? "⤡" : "⤢";
-      }
-    }
-    if (shouldEnable) {
-      setNotesDrawer(false);
-      closeHeaderMenu();
-    }
-  }
-
-  function setToolbarVisibility(visible) {
-    const shouldShow = Boolean(visible);
-    document.body.classList.toggle("show-toolbar", shouldShow);
-    if (ui.toolbarToggle) {
-      ui.toolbarToggle.setAttribute("aria-pressed", String(shouldShow));
-      const label = ui.toolbarToggle.querySelector(".sr-only");
-      if (label) {
-        label.textContent = shouldShow
-          ? "Masquer la barre d'outils"
-          : "Afficher la barre d'outils";
-      }
-      ui.toolbarToggle.setAttribute(
-        "aria-label",
-        shouldShow ? "Masquer la barre d'outils" : "Afficher la barre d'outils"
-      );
     }
   }
 
@@ -1696,8 +1612,6 @@ function bootstrapApp() {
     ui.logoutBtn.disabled = true;
     closeHeaderMenu();
     setNotesDrawer(false);
-    setFocusMode(false);
-    setToolbarVisibility(false);
     setSidebarCollapsed(false);
     try {
       await flushPendingSave();

--- a/index.html
+++ b/index.html
@@ -110,16 +110,6 @@
                 <div class="editor-header-actions">
                   <button
                     type="button"
-                    id="toggle-focus-btn"
-                    class="icon-button ghost"
-                    aria-pressed="false"
-                    aria-label="Activer le mode focus"
-                  >
-                    <span aria-hidden="true">⤢</span>
-                    <span class="sr-only">Activer le mode focus</span>
-                  </button>
-                  <button
-                    type="button"
                     id="restore-sidebar-btn"
                     class="icon-button ghost"
                     aria-label="Afficher la liste des fiches"
@@ -128,16 +118,6 @@
                   >
                     <span aria-hidden="true">☰</span>
                     <span class="sr-only">Afficher la liste des fiches</span>
-                  </button>
-                  <button
-                    type="button"
-                    id="show-toolbar-btn"
-                    class="icon-button ghost mobile-only"
-                    aria-pressed="false"
-                    aria-label="Afficher la barre d'outils"
-                  >
-                    <span aria-hidden="true">☰</span>
-                    <span class="sr-only">Afficher la barre d'outils</span>
                   </button>
                 </div>
               </div>

--- a/styles.css
+++ b/styles.css
@@ -32,30 +32,6 @@ body.notes-drawer-open {
   overflow: hidden;
 }
 
-body.focus-mode {
-  --toolbar-offset: 1.25rem;
-}
-
-body.focus-mode .app-header {
-  transform: translateY(-120%);
-  opacity: 0;
-  pointer-events: none;
-}
-
-body.focus-mode .app-main {
-  padding-top: 1rem;
-}
-
-body.focus-mode .workspace {
-  grid-template-columns: minmax(0, 1fr);
-}
-
-body.focus-mode .note-list {
-  opacity: 0;
-  pointer-events: none;
-  transform: translateX(-2rem);
-}
-
 h1,
 h2,
 h3,
@@ -156,10 +132,6 @@ input[type="text"]:focus {
   background: #ffffff;
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
-  position: sticky;
-  top: 0;
-  z-index: 12;
-  transition: transform 0.3s ease, opacity 0.3s ease;
 }
 
 .brand h1 {
@@ -210,10 +182,6 @@ input[type="text"]:focus {
 .header-icon-button[aria-pressed="true"] {
   background: rgba(26, 115, 232, 0.18);
   color: var(--accent-strong);
-}
-
-.mobile-only {
-  display: none;
 }
 
 .header-actions {
@@ -1019,10 +987,6 @@ body.notes-drawer-open .drawer-overlay {
     font-size: 0.85rem;
   }
 
-  .mobile-only {
-    display: inline-flex;
-  }
-
   .brand {
     gap: 0.5rem;
   }
@@ -1170,10 +1134,6 @@ body.notes-drawer-open .drawer-overlay {
   .editor-header-actions {
     width: 100%;
     justify-content: flex-end;
-  }
-
-  body:not(.show-toolbar) .editor-toolbar {
-    display: none;
   }
 
   .editor-wrapper {


### PR DESCRIPTION
## Summary
- remove the focus-mode and toolbar toggle buttons from the editor header
- clean up the layout logic now that these controls are gone
- let the top banner scroll with the page instead of staying sticky

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d597f2c1d883339483a81f64f5fafd