### PR TITLE
Make header sticky and remove duplicate toggle

### DIFF
--- a/app.js
+++ b/app.js
@@ -208,7 +208,6 @@ function bootstrapApp() {
     fontFamily: document.getElementById("font-family"),
     fontSizeValue: document.getElementById("font-size-value"),
     clozeFeedback: document.getElementById("cloze-feedback"),
-    sidebarRestore: document.getElementById("restore-sidebar-btn"),
     workspaceOverlay: document.getElementById("drawer-overlay"),
     mobileNotesBtn: document.getElementById("mobile-notes-btn")
   };
@@ -289,15 +288,6 @@ function bootstrapApp() {
   function setupLayoutControls() {
     setSidebarCollapsed(false);
 
-    if (ui.sidebarRestore) {
-      ui.sidebarRestore.addEventListener("click", () => {
-        setSidebarCollapsed(false);
-        if (ui.mobileNotesBtn && !mobileMediaQuery.matches) {
-          ui.mobileNotesBtn.focus();
-        }
-      });
-    }
-
     if (ui.headerMenuBtn && ui.headerMenu) {
       ui.headerMenuBtn.addEventListener("click", (event) => {
         event.stopPropagation();
@@ -357,10 +347,6 @@ function bootstrapApp() {
       updateNotesButtonForSidebar(!shouldCollapse);
     }
 
-    if (ui.sidebarRestore) {
-      ui.sidebarRestore.hidden = !shouldCollapse;
-      ui.sidebarRestore.setAttribute("aria-hidden", String(!shouldCollapse));
-    }
   }
 
   function setNotesDrawer(open) {

--- a/index.html
+++ b/index.html
@@ -107,19 +107,6 @@
                   />
                   <span id="save-status" class="save-status muted"></span>
                 </div>
-                <div class="editor-header-actions">
-                  <button
-                    type="button"
-                    id="restore-sidebar-btn"
-                    class="icon-button ghost"
-                    aria-label="Afficher la liste des fiches"
-                    aria-hidden="true"
-                    hidden
-                  >
-                    <span aria-hidden="true">☰</span>
-                    <span class="sr-only">Afficher la liste des fiches</span>
-                  </button>
-                </div>
               </div>
               <div class="editor-toolbar" aria-label="Outils de mise en forme">
                 <div class="toolbar-group toolbar-group--primary">

--- a/styles.css
+++ b/styles.css
@@ -11,7 +11,7 @@
   --success: #188038;
   --warning: #f9ab00;
   --header-height: 4rem;
-  --toolbar-offset: calc(var(--header-height) + 0.5rem);
+  --toolbar-offset: var(--header-height);
   font-family: "Inter", "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -124,6 +124,9 @@ input[type="text"]:focus {
 
 
 .app-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -480,27 +483,8 @@ input[type="text"]:focus {
   gap: 0.35rem;
 }
 
-.editor-header-actions {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-}
-
-#restore-sidebar-btn {
-  display: inline-flex;
-}
-
-.editor-header-actions .icon-button {
-  padding: 0.35rem 0.55rem;
-}
-
 .editor-header-main .save-status {
   justify-self: end;
-}
-
-.editor-header-actions .icon-button span[aria-hidden="true"] {
-  font-size: 1.1rem;
-  line-height: 1;
 }
 
 .editor-toolbar {


### PR DESCRIPTION
## Summary
- remove the duplicate sidebar toggle button from the editor header
- keep the global menu button visible by making the top header sticky
- align the formatting toolbar directly beneath the header when scrolling

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59add0c848333b51f484683771e91