### PR TITLE
Masquer le bandeau principal lors du défilement

### DIFF
--- a/app.js
+++ b/app.js
@@ -213,6 +213,24 @@ function bootstrapApp() {
   };
 
   const workspaceLayout = document.querySelector(".workspace");
+  const bodyElement = document.body;
+
+  const SCROLL_COLLAPSE_THRESHOLD = 24;
+
+  function updateHeaderCollapseState() {
+    if (!bodyElement) {
+      return;
+    }
+
+    if (window.scrollY > SCROLL_COLLAPSE_THRESHOLD) {
+      bodyElement.classList.add("header-collapsed");
+    } else {
+      bodyElement.classList.remove("header-collapsed");
+    }
+  }
+
+  window.addEventListener("scroll", updateHeaderCollapseState, { passive: true });
+  updateHeaderCollapseState();
 
   showView(null);
   ui.logoutBtn.disabled = true;

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,10 @@
   font-family: "Inter", "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
+body {
+  --toolbar-offset: var(--header-height);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -135,6 +139,7 @@ input[type="text"]:focus {
   background: #ffffff;
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
+  transition: top 0.25s ease, box-shadow 0.2s ease;
 }
 
 .brand h1 {
@@ -249,6 +254,47 @@ input[type="text"]:focus {
 
 .header-menu .menu-item:hover {
   background: rgba(26, 115, 232, 0.12);
+  color: var(--accent-strong);
+}
+
+body.header-collapsed {
+  --toolbar-offset: 0;
+}
+
+body.header-collapsed .app-header {
+  top: 0;
+  min-height: 0;
+  height: 0;
+  padding: 0;
+  border-bottom: none;
+  box-shadow: none;
+}
+
+body.header-collapsed .brand-text,
+body.header-collapsed .header-actions {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+body.header-collapsed #mobile-notes-btn {
+  position: fixed;
+  top: 0.75rem;
+  left: 1.5rem;
+  z-index: 50;
+  background: #ffffff;
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 6px rgba(60, 64, 67, 0.18);
+  color: var(--fg);
+}
+
+body.header-collapsed #mobile-notes-btn:hover {
+  background: rgba(60, 64, 67, 0.12);
+}
+
+body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
+  background: rgba(26, 115, 232, 0.12);
+  border-color: rgba(26, 115, 232, 0.35);
   color: var(--accent-strong);
 }
 


### PR DESCRIPTION
## Summary
- masque le bandeau de marque lors du défilement et maintient le bouton d’accès aux fiches visible
- ajuste la barre d’outils de l’éditeur pour qu’elle s’aligne en haut de l’écran lorsque l’en-tête est masqué

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59e02fbf88333b46a3bdbf430ac23