### PR TITLE
Refine editor toolbar responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,55 +109,8 @@
                 </div>
               </div>
               <div class="editor-toolbar" aria-label="Outils de mise en forme">
-                <div class="toolbar-primary-row">
-                  <div class="toolbar-group toolbar-group--primary">
-                    <label class="toolbar-select">
-                      <span class="sr-only">Style de texte</span>
-                      <select id="block-format" data-command="formatBlock" aria-label="Style de texte">
-                        <option value="p" selected>Normal</option>
-                        <option value="h1">Titre 1</option>
-                      <option value="h2">Titre 2</option>
-                      <option value="h3">Titre 3</option>
-                      <option value="blockquote">Citation</option>
-                    </select>
-                  </label>
-                  <label class="toolbar-select">
-                    <span class="sr-only">Police</span>
-                    <select id="font-family" data-command="fontName" aria-label="Police">
-                      <option value="Arial" selected>Arial</option>
-                      <option value="Georgia">Georgia</option>
-                      <option value="Inter">Inter</option>
-                      <option value="Times New Roman">Times New Roman</option>
-                      <option value="Trebuchet MS">Trebuchet</option>
-                      <option value="Verdana">Verdana</option>
-                    </select>
-                  </label>
-                    <div class="font-size-control" role="group" aria-label="Taille du texte">
-                      <button type="button" class="toolbar-button" data-action="decreaseFontSize" title="Diminuer la taille">
-                        <span aria-hidden="true">−</span>
-                        <span class="sr-only">Diminuer la taille</span>
-                      </button>
-                      <span id="font-size-value" aria-live="polite">11</span>
-                      <button type="button" class="toolbar-button" data-action="increaseFontSize" title="Augmenter la taille">
-                        <span aria-hidden="true">+</span>
-                        <span class="sr-only">Augmenter la taille</span>
-                      </button>
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="toolbar-button toolbar-more-button"
-                    id="toolbar-more-btn"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    aria-controls="toolbar-more-panel"
-                  >
-                    <span class="icon" aria-hidden="true">☰</span>
-                    <span>Autres outils</span>
-                  </button>
-                </div>
-                <div class="toolbar-more-panel" id="toolbar-more-panel">
-                  <div class="toolbar-group">
+                <div class="toolbar-quick-actions" role="toolbar" aria-label="Raccourcis de mise en forme">
+                  <div class="toolbar-group toolbar-group--quick">
                     <button type="button" class="toolbar-button" data-command="bold" title="Gras (Ctrl+B)">
                       <span class="icon" aria-hidden="true">B</span>
                       <span class="sr-only">Gras</span>
@@ -171,7 +124,17 @@
                       <span class="sr-only">Souligner</span>
                     </button>
                   </div>
-                  <div class="toolbar-group">
+                  <div class="toolbar-group toolbar-group--quick">
+                    <button type="button" class="toolbar-button" data-command="insertUnorderedList" title="Liste à puces">
+                      <span class="icon" aria-hidden="true">•</span>
+                      <span class="sr-only">Liste à puces</span>
+                    </button>
+                    <button type="button" class="toolbar-button" data-command="insertOrderedList" title="Liste numérotée">
+                      <span class="icon" aria-hidden="true">1.</span>
+                      <span class="sr-only">Liste numérotée</span>
+                    </button>
+                  </div>
+                  <div class="toolbar-group toolbar-group--quick">
                     <button
                       type="button"
                       class="toolbar-button color-tool"
@@ -188,6 +151,56 @@
                       <span class="color-bar highlight" aria-hidden="true"></span>
                       <span class="sr-only">Surligner la sélection</span>
                     </button>
+                  </div>
+                  <button
+                    type="button"
+                    class="toolbar-button toolbar-more-button"
+                    id="toolbar-more-btn"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="toolbar-more-panel"
+                    title="Afficher plus d’options"
+                  >
+                    <span class="icon" aria-hidden="true">⋮</span>
+                    <span class="sr-only">Plus d’outils</span>
+                  </button>
+                </div>
+                <div class="toolbar-more-panel" id="toolbar-more-panel">
+                  <div class="toolbar-group toolbar-group--primary">
+                    <label class="toolbar-select">
+                      <span class="sr-only">Style de texte</span>
+                      <select id="block-format" data-command="formatBlock" aria-label="Style de texte">
+                        <option value="p" selected>Normal</option>
+                        <option value="h1">Titre 1</option>
+                        <option value="h2">Titre 2</option>
+                        <option value="h3">Titre 3</option>
+                        <option value="blockquote">Citation</option>
+                      </select>
+                    </label>
+                    <label class="toolbar-select">
+                      <span class="sr-only">Police</span>
+                      <select id="font-family" data-command="fontName" aria-label="Police">
+                        <option value="Arial" selected>Arial</option>
+                        <option value="Georgia">Georgia</option>
+                        <option value="Inter">Inter</option>
+                        <option value="Times New Roman">Times New Roman</option>
+                        <option value="Trebuchet MS">Trebuchet</option>
+                        <option value="Verdana">Verdana</option>
+                      </select>
+                    </label>
+                    <div class="font-size-control" role="group" aria-label="Taille du texte">
+                      <button type="button" class="toolbar-button" data-action="decreaseFontSize" title="Diminuer la taille">
+                        <span aria-hidden="true">−</span>
+                        <span class="sr-only">Diminuer la taille</span>
+                      </button>
+                      <span id="font-size-value" aria-live="polite">11</span>
+                      <button type="button" class="toolbar-button" data-action="increaseFontSize" title="Augmenter la taille">
+                        <span aria-hidden="true">+</span>
+                        <span class="sr-only">Augmenter la taille</span>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="toolbar-group toolbar-group--advanced">
                     <button type="button" class="toolbar-button" data-action="createCloze" title="Transformer la sélection en trou">
                       <span class="icon" aria-hidden="true">[…]</span>
                       <span class="sr-only">Créer un trou</span>
@@ -201,16 +214,6 @@
                     >
                       <span class="icon" aria-hidden="true">🔁</span>
                       <span>Nouvelle itération</span>
-                    </button>
-                  </div>
-                  <div class="toolbar-group">
-                    <button type="button" class="toolbar-button" data-command="insertUnorderedList" title="Liste à puces">
-                      <span class="icon" aria-hidden="true">•</span>
-                      <span class="sr-only">Liste à puces</span>
-                    </button>
-                    <button type="button" class="toolbar-button" data-command="insertOrderedList" title="Liste numérotée">
-                      <span class="icon" aria-hidden="true">1.</span>
-                      <span class="sr-only">Liste numérotée</span>
                     </button>
                     <button type="button" class="toolbar-button" data-command="removeFormat" title="Effacer la mise en forme">
                       <span class="icon" aria-hidden="true">⨯</span>

--- a/styles.css
+++ b/styles.css
@@ -538,10 +538,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   top: var(--toolbar-offset);
   left: 0;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.65rem 0.85rem;
-  padding: 0.55rem 0.75rem;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+  padding: 0.6rem 0.75rem;
   background: #ffffff;
   border-radius: 0.75rem;
   border: 1px solid var(--border);
@@ -552,17 +552,23 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   z-index: 4;
 }
 
-.toolbar-primary-row {
+.toolbar-quick-actions {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  flex: 1 1 320px;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .toolbar-more-button {
+  margin-left: auto;
   display: none;
-  white-space: nowrap;
-  gap: 0.4rem;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0.35rem;
+}
+
+.toolbar-more-button .icon {
+  font-size: 1.2rem;
 }
 
 .toolbar-more-panel {
@@ -574,7 +580,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .toolbar-group {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 0.35rem;
   padding-right: 0.75rem;
@@ -589,6 +595,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   padding-right: 0;
 }
 
+.toolbar-group--quick {
+  border-right: none;
+  margin-right: 0;
+  padding-right: 0;
+  gap: 0.3rem;
+}
+
 .toolbar-group--primary {
   flex: 1 1 320px;
   gap: 0.5rem;
@@ -601,6 +614,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .toolbar-group--primary > .font-size-control {
   flex: 1 1 140px;
   justify-content: space-between;
+}
+
+.toolbar-group--advanced {
+  gap: 0.5rem;
 }
 
 .toolbar-select {
@@ -1089,50 +1106,69 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-area {
-    padding: 1rem 1rem 1.75rem;
+    padding: 1rem 1rem 5.75rem;
     min-height: calc(100vh - var(--header-height) - 2.5rem);
   }
 
   .editor-toolbar {
-    flex-direction: column;
-    align-items: stretch;
-    padding: 0.5rem 0.6rem;
-    gap: 0.6rem;
+    position: sticky;
+    top: auto;
+    bottom: calc(env(safe-area-inset-bottom, 0) + 0.75rem);
+    margin: 0 auto;
+    padding: 0.45rem 0.55rem;
+    gap: 0.45rem;
+    border-radius: 1rem;
+    box-shadow: 0 12px 28px rgba(60, 64, 67, 0.24);
   }
 
-  .toolbar-primary-row {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.55rem;
+  .toolbar-quick-actions {
     width: 100%;
+    justify-content: center;
+    gap: 0.35rem;
   }
 
   .toolbar-group {
-    width: 100%;
-    flex-wrap: wrap;
-    white-space: normal;
-  }
-
-  .toolbar-group--primary {
-    border-right: none;
+    border: none;
     margin-right: 0;
     padding-right: 0;
-    min-width: 0;
+    width: auto;
+  }
+
+  .toolbar-group--quick {
+    flex: 1 1 auto;
+    justify-content: center;
+    gap: 0.25rem;
+  }
+
+  .toolbar-group--quick .toolbar-button {
+    min-width: 2.4rem;
+    min-height: 2.4rem;
+    font-size: 1.05rem;
+    padding: 0.35rem;
   }
 
   .toolbar-more-button {
     display: inline-flex;
-    align-self: flex-start;
+    margin-left: 0;
+    min-width: 2.6rem;
+    min-height: 2.6rem;
   }
 
   .toolbar-more-panel {
     display: none;
+    position: fixed;
+    left: 0.85rem;
+    right: 0.85rem;
+    bottom: calc(4.75rem + env(safe-area-inset-bottom, 0));
     flex-direction: column;
-    gap: 0.65rem;
-    background: #f8f9fa;
+    align-items: stretch;
+    gap: 0.75rem;
+    background: #ffffff;
     border: 1px solid var(--border);
-    border-radius: 0.65rem;
-    padding: 0.65rem;
+    border-radius: 1rem;
+    padding: 0.85rem;
+    box-shadow: 0 18px 36px rgba(60, 64, 67, 0.3);
+    z-index: 40;
   }
 
   .toolbar-more-panel.is-open {
@@ -1140,17 +1176,28 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-more-panel .toolbar-group {
+    width: 100%;
     border: none;
     margin: 0;
-    padding: 0 0 0.55rem;
-    margin-bottom: 0.55rem;
-    border-bottom: 1px solid var(--border);
+    padding: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.6rem;
   }
 
-  .toolbar-more-panel .toolbar-group:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-    margin-bottom: 0;
+  .toolbar-more-panel .toolbar-group.toolbar-group--primary {
+    gap: 0.75rem;
+  }
+
+  .toolbar-more-panel .toolbar-group.toolbar-group--primary > .toolbar-select,
+  .toolbar-more-panel .toolbar-group.toolbar-group--primary > .font-size-control {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+
+  .toolbar-more-panel .toolbar-group .toolbar-button {
+    width: 100%;
+    justify-content: center;
   }
 
   .editor-header {
@@ -1215,26 +1262,43 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-area {
-    padding: 0.75rem 0.85rem 1.5rem;
-    min-height: calc(100vh - var(--header-height) - 1.5rem);
+    padding: 0.75rem 0.85rem 5.25rem;
+    min-height: calc(100vh - var(--header-height));
   }
 
   .editor-toolbar {
-    padding: 0.45rem 0.5rem;
-    gap: 0.5rem;
+    padding: 0.35rem 0.45rem;
+    gap: 0.4rem;
   }
 
-  .toolbar-group--primary {
-    min-width: 240px;
+  .toolbar-quick-actions {
+    gap: 0.3rem;
+  }
+
+  .toolbar-group--quick {
+    gap: 0.2rem;
+  }
+
+  .toolbar-group--quick .toolbar-button {
+    min-width: 2.2rem;
+    min-height: 2.2rem;
+    font-size: 0.95rem;
+  }
+
+  .toolbar-more-panel {
+    left: 0.65rem;
+    right: 0.65rem;
+    bottom: calc(4.5rem + env(safe-area-inset-bottom, 0));
+    padding: 0.75rem;
   }
 
   .toolbar-select {
-    min-width: 120px;
+    min-width: 0;
   }
 
   .editor {
-    padding: 1.4rem 1.1rem;
-    min-height: calc(100vh - var(--header-height) - 5.5rem);
+    padding: 1.2rem 1rem;
+    min-height: calc(100vh - var(--header-height) - 5rem);
   }
 }
 


### PR DESCRIPTION
## Summary
- restructure the editor toolbar to keep core formatting buttons always visible and move advanced controls behind an overflow menu on small screens while retaining the full desktop experience
- refresh the toolbar styling to support the compact mobile bar, floating overflow panel, and additional spacing so the editor remains usable on phones

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5a5065b8083339cda5f6bc4039b5e