### PR TITLE
Improve mobile editor toolbar persistence

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1041,6 +1041,8 @@ body.notes-drawer-open .drawer-overlay {
 @media (max-width: 900px) {
   :root {
     --header-height: 3.6rem;
+    --mobile-toolbar-spacing: 0.85rem;
+    --mobile-toolbar-bottom: calc(env(safe-area-inset-bottom, 0) + var(--mobile-toolbar-spacing));
   }
 
   .app-header {
@@ -1107,18 +1109,30 @@ body.notes-drawer-open .drawer-overlay {
 
   .editor-area {
     padding: 1rem 1rem 5.75rem;
+    padding: 1rem 1rem calc(5.75rem + env(safe-area-inset-bottom, 0));
     min-height: calc(100vh - var(--header-height) - 2.5rem);
+    min-height: calc(100vh - var(--header-height) - 2.5rem - env(safe-area-inset-bottom, 0));
   }
 
   .editor-toolbar {
-    position: sticky;
-    top: auto;
-    bottom: calc(env(safe-area-inset-bottom, 0) + 0.75rem);
-    margin: 0 auto;
-    padding: 0.45rem 0.55rem;
+    position: fixed;
+    left: 50%;
+    bottom: var(--mobile-toolbar-bottom);
+    transform: translateX(-50%);
+    width: calc(100% - 1.7rem);
+    width: calc(100% - (var(--mobile-toolbar-spacing) * 2));
+    max-width: 520px;
+    margin: 0;
+    padding: 0.5rem 0.65rem;
     gap: 0.45rem;
     border-radius: 1rem;
-    box-shadow: 0 12px 28px rgba(60, 64, 67, 0.24);
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.22);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
+    z-index: 20;
+    align-self: center;
   }
 
   .toolbar-quick-actions {
@@ -1157,17 +1171,23 @@ body.notes-drawer-open .drawer-overlay {
   .toolbar-more-panel {
     display: none;
     position: fixed;
-    left: 0.85rem;
-    right: 0.85rem;
-    bottom: calc(4.75rem + env(safe-area-inset-bottom, 0));
+    left: 50%;
+    right: auto;
+    bottom: calc(var(--mobile-toolbar-bottom) + 4.25rem);
+    transform: translateX(-50%);
+    width: calc(100% - 1.7rem);
+    width: calc(100% - (var(--mobile-toolbar-spacing) * 2));
+    max-width: 520px;
     flex-direction: column;
     align-items: stretch;
     gap: 0.75rem;
-    background: #ffffff;
-    border: 1px solid var(--border);
+    background: rgba(255, 255, 255, 0.97);
+    border: 1px solid rgba(15, 23, 42, 0.12);
     border-radius: 1rem;
     padding: 0.85rem;
-    box-shadow: 0 18px 36px rgba(60, 64, 67, 0.3);
+    box-shadow: 0 24px 46px rgba(15, 23, 42, 0.28);
+    backdrop-filter: blur(18px);
+    -webkit-backdrop-filter: blur(18px);
     z-index: 40;
   }
 
@@ -1248,6 +1268,11 @@ body.notes-drawer-open .drawer-overlay {
 }
 
 @media (max-width: 560px) {
+  :root {
+    --mobile-toolbar-spacing: 0.65rem;
+    --mobile-toolbar-bottom: calc(env(safe-area-inset-bottom, 0) + var(--mobile-toolbar-spacing));
+  }
+
   .app-main {
     padding: 1rem 1rem 1.75rem;
   }
@@ -1263,11 +1288,13 @@ body.notes-drawer-open .drawer-overlay {
 
   .editor-area {
     padding: 0.75rem 0.85rem 5.25rem;
+    padding: 0.75rem 0.85rem calc(5.25rem + env(safe-area-inset-bottom, 0));
     min-height: calc(100vh - var(--header-height));
+    min-height: calc(100vh - var(--header-height) - env(safe-area-inset-bottom, 0));
   }
 
   .editor-toolbar {
-    padding: 0.35rem 0.45rem;
+    padding: 0.35rem 0.5rem;
     gap: 0.4rem;
   }
 
@@ -1286,9 +1313,7 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-more-panel {
-    left: 0.65rem;
-    right: 0.65rem;
-    bottom: calc(4.5rem + env(safe-area-inset-bottom, 0));
+    bottom: calc(var(--mobile-toolbar-bottom) + 3.9rem);
     padding: 0.75rem;
   }
 
@@ -1299,6 +1324,7 @@ body.notes-drawer-open .drawer-overlay {
   .editor {
     padding: 1.2rem 1rem;
     min-height: calc(100vh - var(--header-height) - 5rem);
+    min-height: calc(100vh - var(--header-height) - 5rem - env(safe-area-inset-bottom, 0));
   }
 }
 


### PR DESCRIPTION
## Summary
- anchor the mobile editor toolbar so it stays fixed above the keyboard with safe-area spacing
- refresh the floating toolbar styling to give it a clearer anchored appearance
- realign the overflow menu panel with the new toolbar placement and spacing

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5a7ce473c8333b7227dd8bfa1ba7b