### PR TITLE
Improve editor toolbar ergonomics

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -12,6 +12,8 @@
   --warning: #f9ab00;
   --header-height: 4rem;
   --toolbar-offset: var(--header-height);
+  --toolbar-sticky-gap: 1rem;
+  --editor-toolbar-surface: rgba(255, 255, 255, 0.97);
   --mobile-toolbar-spacing: 0.85rem;
   --mobile-toolbar-keyboard-offset: env(keyboard-inset-height, 0);
   --mobile-toolbar-bottom: max(
@@ -545,17 +547,19 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-toolbar {
   position: sticky;
-  top: var(--toolbar-offset);
+  top: calc(var(--toolbar-offset) + var(--toolbar-sticky-gap));
   left: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 0.75rem;
   padding: 0.6rem 0.75rem;
-  background: #ffffff;
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.16);
+  background: var(--editor-toolbar-surface);
+  border-radius: 0.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14), 0 6px 12px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
   width: 100%;
   align-self: stretch;
   margin-bottom: 0.75rem;
@@ -566,7 +570,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
-  gap: 0.5rem;
+  gap: 0.65rem;
 }
 
 .toolbar-more-button {
@@ -609,7 +613,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-right: none;
   margin-right: 0;
   padding-right: 0;
-  gap: 0.3rem;
+  gap: 0.45rem;
 }
 
 .toolbar-group--primary {
@@ -690,12 +694,12 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-toolbar .toolbar-button {
   background: #f8f9fa;
-  border-radius: 0.5rem;
+  border-radius: 0.55rem;
   border: 1px solid transparent;
   color: var(--fg);
-  padding: 0.3rem 0.5rem;
-  min-width: 2.2rem;
-  min-height: 2.2rem;
+  padding: 0.35rem 0.55rem;
+  min-width: 2.45rem;
+  min-height: 2.45rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1139,8 +1143,8 @@ body.notes-drawer-open .drawer-overlay {
     padding: 0.5rem 0.65rem;
     gap: 0.45rem;
     border-radius: 1rem;
-    background: rgba(255, 255, 255, 0.98);
-    border: 1px solid rgba(15, 23, 42, 0.1);
+    background: var(--editor-toolbar-surface);
+    border: 1px solid rgba(15, 23, 42, 0.12);
     box-shadow: 0 -1px 0 rgba(15, 23, 42, 0.05), 0 12px 28px rgba(15, 23, 42, 0.18),
       0 4px 12px rgba(15, 23, 42, 0.14);
     backdrop-filter: blur(18px);
@@ -1152,7 +1156,7 @@ body.notes-drawer-open .drawer-overlay {
   .toolbar-quick-actions {
     width: 100%;
     justify-content: center;
-    gap: 0.35rem;
+    gap: 0.45rem;
   }
 
   .toolbar-group {
@@ -1165,14 +1169,14 @@ body.notes-drawer-open .drawer-overlay {
   .toolbar-group--quick {
     flex: 1 1 auto;
     justify-content: center;
-    gap: 0.25rem;
+    gap: 0.35rem;
   }
 
   .toolbar-group--quick .toolbar-button {
-    min-width: 2.4rem;
-    min-height: 2.4rem;
+    min-width: 2.55rem;
+    min-height: 2.55rem;
     font-size: 1.05rem;
-    padding: 0.35rem;
+    padding: 0.4rem;
   }
 
   .toolbar-more-button {


### PR DESCRIPTION
## Summary
- keep the editor toolbar anchored beneath the header with a dedicated sticky offset
- improve visual separation using a translucent surface, border and stronger shadows
- widen spacing and hit areas of quick actions on desktop and mobile for better touch comfort

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b0e8b1c483338a1e2e73c5ac5ed7