### PR TITLE
Refonte du tableau de bord et synchronisation du filtre

### DIFF
--- a/app.js
+++ b/app.js
@@ -147,6 +147,147 @@ function bootstrapApp() {
   const CLOZE_MANUAL_REVEAL_DATASET_KEY = "manualReveal";
   const CLOZE_MANUAL_REVEAL_ATTR = "data-manual-reveal";
 
+  const DASHBOARD_DEFAULT_PERIOD = 10;
+  const DASHBOARD_RESPONSE_MAP = {
+    yes: { label: "Oui", className: "dashboard-response--yes", score: 5 },
+    "rather-yes": {
+      label: "Plutôt oui",
+      className: "dashboard-response--rather-yes",
+      score: 4
+    },
+    neutral: { label: "Neutre", className: "dashboard-response--neutral", score: 3 },
+    "rather-no": {
+      label: "Plutôt non",
+      className: "dashboard-response--rather-no",
+      score: 2
+    },
+    no: { label: "Non", className: "dashboard-response--no", score: 1 }
+  };
+  const DASHBOARD_LINE_COLORS = [
+    "#2563eb",
+    "#7c3aed",
+    "#059669",
+    "#d97706",
+    "#dc2626",
+    "#0ea5e9",
+    "#9333ea"
+  ];
+  const DASHBOARD_SAMPLE_DATA = {
+    iterations: Array.from({ length: 16 }, (_, index) => index + 1),
+    consignes: [
+      {
+        id: "consigne-1",
+        label: "Présenter la notion centrale",
+        responses: {
+          16: "yes",
+          15: "rather-yes",
+          14: "yes",
+          13: "neutral",
+          12: "yes",
+          11: "yes",
+          10: "rather-yes",
+          9: "neutral",
+          8: "yes",
+          7: "yes",
+          6: "rather-yes",
+          5: "neutral",
+          4: "yes",
+          3: "rather-yes",
+          2: "neutral",
+          1: "rather-no"
+        }
+      },
+      {
+        id: "consigne-2",
+        label: "Donner un exemple concret",
+        responses: {
+          16: "rather-yes",
+          15: "rather-yes",
+          14: "neutral",
+          13: "rather-yes",
+          12: "yes",
+          11: "yes",
+          10: "neutral",
+          9: "neutral",
+          8: "rather-yes",
+          7: "neutral",
+          6: "rather-no",
+          5: "rather-no",
+          4: "neutral",
+          3: "rather-no",
+          2: "rather-no",
+          1: "no"
+        }
+      },
+      {
+        id: "consigne-3",
+        label: "Décrire la procédure étape par étape",
+        responses: {
+          16: "yes",
+          15: "yes",
+          14: "rather-yes",
+          13: "rather-yes",
+          12: "neutral",
+          11: "rather-yes",
+          10: "rather-yes",
+          9: "neutral",
+          8: "rather-no",
+          7: "neutral",
+          6: "neutral",
+          5: "rather-no",
+          4: "rather-no",
+          3: "neutral",
+          2: "no",
+          1: "no"
+        }
+      },
+      {
+        id: "consigne-4",
+        label: "Identifier les erreurs fréquentes",
+        responses: {
+          16: "neutral",
+          15: "neutral",
+          14: "rather-no",
+          13: "rather-no",
+          12: "rather-no",
+          11: "neutral",
+          10: "rather-yes",
+          9: "neutral",
+          8: "neutral",
+          7: "rather-yes",
+          6: "rather-yes",
+          5: "neutral",
+          4: "neutral",
+          3: "rather-no",
+          2: "rather-no",
+          1: "no"
+        }
+      },
+      {
+        id: "consigne-5",
+        label: "Synthétiser le point clé",
+        responses: {
+          16: "yes",
+          15: "yes",
+          14: "yes",
+          13: "rather-yes",
+          12: "rather-yes",
+          11: "neutral",
+          10: "rather-yes",
+          9: "rather-yes",
+          8: "neutral",
+          7: "neutral",
+          6: "rather-no",
+          5: "rather-no",
+          4: "neutral",
+          3: "rather-yes",
+          2: "rather-yes",
+          1: "neutral"
+        }
+      }
+    ]
+  };
+
   const relativeTime = new Intl.RelativeTimeFormat("fr", { numeric: "auto" });
   const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
     day: "2-digit",
@@ -172,7 +313,8 @@ function bootstrapApp() {
     pendingRemoteNote: null,
     isEditorFocused: false,
     savedSelection: null,
-    [CLOZE_MANUAL_REVEAL_SET_KEY]: new WeakSet()
+    [CLOZE_MANUAL_REVEAL_SET_KEY]: new WeakSet(),
+    dashboard: null
   };
 
   function getManualRevealSet() {
@@ -211,7 +353,15 @@ function bootstrapApp() {
     workspaceOverlay: document.getElementById("drawer-overlay"),
     mobileNotesBtn: document.getElementById("mobile-notes-btn"),
     toolbarMoreBtn: document.getElementById("toolbar-more-btn"),
-    toolbarMorePanel: document.getElementById("toolbar-more-panel")
+    toolbarMorePanel: document.getElementById("toolbar-more-panel"),
+    dashboardPanel: document.getElementById("dashboard-panel"),
+    dashboardPeriodButtons: Array.from(
+      document.querySelectorAll("[data-dashboard-period]") || []
+    ),
+    dashboardTableHead: document.getElementById("dashboard-table-head"),
+    dashboardTableBody: document.getElementById("dashboard-table-body"),
+    dashboardChart: document.getElementById("dashboard-chart"),
+    dashboardLegend: document.getElementById("dashboard-legend")
   };
 
   const workspaceLayout = document.querySelector(".workspace");
@@ -234,6 +384,339 @@ function bootstrapApp() {
 
   window.addEventListener("scroll", updateHeaderCollapseState, { passive: true });
   updateHeaderCollapseState();
+
+  function getDashboardColor(consigneId, index) {
+    if (!state.dashboard) {
+      return DASHBOARD_LINE_COLORS[index % DASHBOARD_LINE_COLORS.length];
+    }
+    if (!state.dashboard.colorByConsigne) {
+      state.dashboard.colorByConsigne = new Map();
+    }
+    if (!state.dashboard.colorByConsigne.has(consigneId)) {
+      const color = DASHBOARD_LINE_COLORS[index % DASHBOARD_LINE_COLORS.length];
+      state.dashboard.colorByConsigne.set(consigneId, color);
+    }
+    return state.dashboard.colorByConsigne.get(consigneId);
+  }
+
+  function assignDashboardColors() {
+    if (!state.dashboard) return;
+    const consignes = state.dashboard.data?.consignes || [];
+    state.dashboard.colorByConsigne = new Map();
+    consignes.forEach((consigne, index) => {
+      const color = DASHBOARD_LINE_COLORS[index % DASHBOARD_LINE_COLORS.length];
+      state.dashboard.colorByConsigne.set(consigne.id, color);
+    });
+  }
+
+  function handleDashboardPeriodClick(event) {
+    if (!state.dashboard) return;
+    const target = event.currentTarget;
+    if (!target) return;
+    const nextPeriod = Number.parseInt(target.dataset.dashboardPeriod, 10);
+    if (!Number.isFinite(nextPeriod)) return;
+    if (state.dashboard.period === nextPeriod) return;
+    state.dashboard.period = nextPeriod;
+    renderDashboard();
+  }
+
+  function getDashboardIterations() {
+    if (!state.dashboard) return [];
+    const iterations = Array.isArray(state.dashboard.data?.iterations)
+      ? [...state.dashboard.data.iterations]
+      : [];
+    iterations.sort((a, b) => a - b);
+    const period = state.dashboard.period || DASHBOARD_DEFAULT_PERIOD;
+    const start = Math.max(0, iterations.length - period);
+    return iterations.slice(start).reverse();
+  }
+
+  function updateDashboardPeriodButtons() {
+    if (!state.dashboard || !ui.dashboardPeriodButtons) return;
+    const currentPeriod = state.dashboard.period;
+    ui.dashboardPeriodButtons.forEach((button) => {
+      const period = Number.parseInt(button.dataset.dashboardPeriod, 10);
+      const isActive = period === currentPeriod;
+      button.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
+  }
+
+  function renderDashboardTable(iterations) {
+    if (!ui.dashboardTableHead || !ui.dashboardTableBody) return;
+    const consignes = state.dashboard?.data?.consignes || [];
+    ui.dashboardTableHead.innerHTML = "";
+    ui.dashboardTableBody.innerHTML = "";
+
+    const headerRow = ui.dashboardTableHead;
+    const consigneHeader = document.createElement("th");
+    consigneHeader.textContent = "Consigne";
+    headerRow.appendChild(consigneHeader);
+
+    if (iterations.length) {
+      iterations.forEach((iteration) => {
+        const th = document.createElement("th");
+        th.textContent = `Itération ${iteration}`;
+        headerRow.appendChild(th);
+      });
+    } else {
+      const placeholder = document.createElement("th");
+      placeholder.textContent = "Aucune itération";
+      headerRow.appendChild(placeholder);
+    }
+
+    if (!iterations.length || !consignes.length) {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = Math.max(2, iterations.length + 1);
+      cell.className = "dashboard-empty-message";
+      cell.textContent = "Aucune donnée à afficher pour cette période.";
+      row.appendChild(cell);
+      ui.dashboardTableBody.appendChild(row);
+      return;
+    }
+
+    const useCompactResponses = iterations.length > 8;
+
+    consignes.forEach((consigne, index) => {
+      const row = document.createElement("tr");
+      const labelCell = document.createElement("td");
+      labelCell.textContent = consigne.label;
+      row.appendChild(labelCell);
+
+      iterations.forEach((iteration) => {
+        const cell = document.createElement("td");
+        const responseKey = consigne.responses?.[iteration];
+        const config = responseKey ? DASHBOARD_RESPONSE_MAP[responseKey] : null;
+        const chip = document.createElement("span");
+        chip.className = "dashboard-response";
+        if (useCompactResponses) {
+          chip.classList.add("small");
+        }
+        if (config) {
+          chip.classList.add(config.className);
+          chip.textContent = config.label;
+          chip.title = `${config.label} pour l'itération ${iteration}`;
+        } else {
+          chip.classList.add("dashboard-response--empty");
+          chip.textContent = "—";
+          chip.title = `Aucune réponse enregistrée pour l'itération ${iteration}`;
+        }
+        cell.appendChild(chip);
+        row.appendChild(cell);
+      });
+
+      ui.dashboardTableBody.appendChild(row);
+    });
+  }
+
+  function renderDashboardLegend() {
+    if (!ui.dashboardLegend) return;
+    ui.dashboardLegend.innerHTML = "";
+    const consignes = state.dashboard?.data?.consignes || [];
+    if (!consignes.length) {
+      const message = document.createElement("p");
+      message.className = "dashboard-empty-message";
+      message.textContent = "Aucune consigne disponible.";
+      ui.dashboardLegend.appendChild(message);
+      return;
+    }
+
+    consignes.forEach((consigne, index) => {
+      const item = document.createElement("div");
+      item.className = "dashboard-legend-item";
+      const swatch = document.createElement("span");
+      swatch.className = "dashboard-legend-swatch";
+      swatch.style.backgroundColor = getDashboardColor(consigne.id, index);
+      item.appendChild(swatch);
+      const label = document.createElement("span");
+      label.textContent = consigne.label;
+      item.appendChild(label);
+      ui.dashboardLegend.appendChild(item);
+    });
+  }
+
+  function renderDashboardChart(iterations) {
+    if (!ui.dashboardChart) return;
+    const svg = ui.dashboardChart;
+    svg.innerHTML = "";
+    const consignes = state.dashboard?.data?.consignes || [];
+
+    if (!iterations.length || !consignes.length) {
+      const width = 480;
+      const height = 220;
+      svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+      const ns = "http://www.w3.org/2000/svg";
+      const text = document.createElementNS(ns, "text");
+      text.setAttribute("x", width / 2);
+      text.setAttribute("y", height / 2);
+      text.setAttribute("text-anchor", "middle");
+      text.setAttribute("fill", "#64748b");
+      text.textContent = "Aucune donnée à afficher";
+      svg.appendChild(text);
+      return;
+    }
+
+    const chronologicalIterations = [...iterations].reverse();
+    const width = Math.max(chronologicalIterations.length * 80, 520);
+    const height = 260;
+    const margin = { top: 24, right: 32, bottom: 40, left: 80 };
+    const chartWidth = Math.max(1, width - margin.left - margin.right);
+    const chartHeight = Math.max(1, height - margin.top - margin.bottom);
+    const ns = "http://www.w3.org/2000/svg";
+
+    svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+
+    const scores = Object.values(DASHBOARD_RESPONSE_MAP).map((config) => config.score);
+    const uniqueScores = Array.from(new Set(scores)).sort((a, b) => a - b);
+    const minScore = uniqueScores[0];
+    const maxScore = uniqueScores[uniqueScores.length - 1];
+    const span = Math.max(1, maxScore - minScore);
+
+    const scoreLabels = uniqueScores.reduce((acc, score) => {
+      const match = Object.values(DASHBOARD_RESPONSE_MAP).find((config) => config.score === score);
+      acc[score] = match ? match.label : `Niveau ${score}`;
+      return acc;
+    }, {});
+
+    const mapScoreToY = (score) => {
+      const ratio = (score - minScore) / span;
+      return margin.top + chartHeight - ratio * chartHeight;
+    };
+
+    const verticalAxis = document.createElementNS(ns, "line");
+    verticalAxis.setAttribute("x1", margin.left);
+    verticalAxis.setAttribute("x2", margin.left);
+    verticalAxis.setAttribute("y1", margin.top);
+    verticalAxis.setAttribute("y2", height - margin.bottom);
+    verticalAxis.setAttribute("class", "chart-axis");
+    svg.appendChild(verticalAxis);
+
+    const horizontalAxis = document.createElementNS(ns, "line");
+    horizontalAxis.setAttribute("x1", margin.left);
+    horizontalAxis.setAttribute("x2", width - margin.right);
+    horizontalAxis.setAttribute("y1", height - margin.bottom);
+    horizontalAxis.setAttribute("y2", height - margin.bottom);
+    horizontalAxis.setAttribute("class", "chart-axis");
+    svg.appendChild(horizontalAxis);
+
+    uniqueScores.forEach((score) => {
+      const y = mapScoreToY(score);
+      const grid = document.createElementNS(ns, "line");
+      grid.setAttribute("x1", margin.left);
+      grid.setAttribute("x2", width - margin.right);
+      grid.setAttribute("y1", y);
+      grid.setAttribute("y2", y);
+      grid.setAttribute("class", "chart-grid");
+      svg.appendChild(grid);
+
+      const label = document.createElementNS(ns, "text");
+      label.setAttribute("x", margin.left - 12);
+      label.setAttribute("y", y + 4);
+      label.setAttribute("text-anchor", "end");
+      label.textContent = scoreLabels[score] || `Niveau ${score}`;
+      svg.appendChild(label);
+    });
+
+    const xPositions = chronologicalIterations.map((iteration, index) => {
+      if (chronologicalIterations.length === 1) {
+        return margin.left + chartWidth / 2;
+      }
+      const ratio = index / (chronologicalIterations.length - 1);
+      return margin.left + ratio * chartWidth;
+    });
+
+    chronologicalIterations.forEach((iteration, index) => {
+      const x = xPositions[index];
+      const label = document.createElementNS(ns, "text");
+      label.setAttribute("x", x);
+      label.setAttribute("y", height - margin.bottom + 24);
+      label.setAttribute("text-anchor", "middle");
+      label.textContent = iteration;
+      svg.appendChild(label);
+    });
+
+    consignes.forEach((consigne, consigneIndex) => {
+      const color = getDashboardColor(consigne.id, consigneIndex);
+      const segments = [];
+      let currentSegment = [];
+
+      chronologicalIterations.forEach((iteration, index) => {
+        const responseKey = consigne.responses?.[iteration];
+        const config = responseKey ? DASHBOARD_RESPONSE_MAP[responseKey] : null;
+        if (!config) {
+          if (currentSegment.length) {
+            segments.push(currentSegment);
+            currentSegment = [];
+          }
+          return;
+        }
+        const point = {
+          x: xPositions[index],
+          y: mapScoreToY(config.score),
+          iteration,
+          label: config.label
+        };
+        currentSegment.push(point);
+      });
+
+      if (currentSegment.length) {
+        segments.push(currentSegment);
+      }
+
+      segments.forEach((segment) => {
+        if (segment.length > 1) {
+          const path = document.createElementNS(ns, "path");
+          let d = `M ${segment[0].x} ${segment[0].y}`;
+          for (let i = 1; i < segment.length; i += 1) {
+            d += ` L ${segment[i].x} ${segment[i].y}`;
+          }
+          path.setAttribute("d", d);
+          path.setAttribute("class", "chart-line");
+          path.setAttribute("stroke", color);
+          svg.appendChild(path);
+        }
+
+        segment.forEach((point) => {
+          const circle = document.createElementNS(ns, "circle");
+          circle.setAttribute("cx", point.x);
+          circle.setAttribute("cy", point.y);
+          circle.setAttribute("r", 4.5);
+          circle.setAttribute("fill", color);
+          circle.setAttribute("class", "chart-point");
+          circle.setAttribute(
+            "aria-label",
+            `${consigne.label} — ${point.label} (itération ${point.iteration})`
+          );
+          svg.appendChild(circle);
+        });
+      });
+    });
+  }
+
+  function renderDashboard() {
+    if (!state.dashboard) return;
+    updateDashboardPeriodButtons();
+    const iterations = getDashboardIterations();
+    renderDashboardTable(iterations);
+    renderDashboardLegend();
+    renderDashboardChart(iterations);
+  }
+
+  function initDashboard() {
+    if (!ui.dashboardPanel) return;
+    state.dashboard = {
+      data: DASHBOARD_SAMPLE_DATA,
+      period: DASHBOARD_DEFAULT_PERIOD,
+      colorByConsigne: new Map()
+    };
+    assignDashboardColors();
+    if (ui.dashboardPeriodButtons && ui.dashboardPeriodButtons.length) {
+      ui.dashboardPeriodButtons.forEach((button) => {
+        button.addEventListener("click", handleDashboardPeriodClick);
+      });
+    }
+    renderDashboard();
+  }
 
   showView(null);
   ui.logoutBtn.disabled = true;
@@ -1747,6 +2230,7 @@ function bootstrapApp() {
     });
   }
 
+  initDashboard();
   initEvents();
   initAuth();
 }

--- a/index.html
+++ b/index.html
@@ -239,6 +239,37 @@
                   <button type="button" data-feedback="no">❌ Non<br /><span>Réponse incorrecte</span></button>
                 </div>
               </div>
+              <section id="dashboard-panel" class="dashboard-panel" aria-labelledby="dashboard-title">
+                <header class="dashboard-header">
+                  <div>
+                    <h2 id="dashboard-title">Tableau de bord</h2>
+                    <p class="muted small">Suivi des dernières itérations par consigne.</p>
+                  </div>
+                  <div class="dashboard-period" role="group" aria-label="Filtrer par période">
+                    <span class="dashboard-period-label">Dernières itérations :</span>
+                    <div class="dashboard-period-options">
+                      <button type="button" data-dashboard-period="5" aria-pressed="false">5</button>
+                      <button type="button" data-dashboard-period="10" aria-pressed="true">10</button>
+                      <button type="button" data-dashboard-period="15" aria-pressed="false">15</button>
+                    </div>
+                  </div>
+                </header>
+                <div class="dashboard-content">
+                  <div class="dashboard-table-wrapper" role="region" aria-live="polite" aria-label="Résultats des itérations">
+                    <table class="dashboard-table">
+                      <thead>
+                        <tr id="dashboard-table-head"></tr>
+                      </thead>
+                      <tbody id="dashboard-table-body"></tbody>
+                    </table>
+                  </div>
+                  <div class="dashboard-chart-wrapper" role="region" aria-label="Tendance des réponses">
+                    <div id="dashboard-legend" class="dashboard-legend" aria-hidden="false"></div>
+                    <svg id="dashboard-chart" class="dashboard-chart" role="img" aria-labelledby="dashboard-chart-title"></svg>
+                    <p id="dashboard-chart-title" class="sr-only">Évolution des réponses par consigne</p>
+                  </div>
+                </div>
+              </section>
             </div>
           </section>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1332,3 +1332,253 @@ body.notes-drawer-open .drawer-overlay {
   }
 }
 
+.dashboard-panel {
+  margin-top: 32px;
+  padding: 24px;
+  background: #ffffff;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dashboard-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-period {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: rgba(15, 23, 42, 0.03);
+  border-radius: 999px;
+}
+
+.dashboard-period-options {
+  display: inline-flex;
+  gap: 6px;
+}
+
+.dashboard-period-options button {
+  border: none;
+  background: transparent;
+  color: #1f2937;
+  font-weight: 600;
+  padding: 6px 14px;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  cursor: pointer;
+}
+
+.dashboard-period-options button[aria-pressed="true"] {
+  background: #1f2937;
+  color: #ffffff;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.12);
+}
+
+.dashboard-period-options button:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.dashboard-content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 32px;
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+  .dashboard-content {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dashboard-table-wrapper {
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #f8fafc;
+}
+
+.dashboard-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  table-layout: fixed;
+  font-size: 0.9rem;
+}
+
+.dashboard-table thead tr {
+  background: #e2e8f0;
+}
+
+.dashboard-table th,
+.dashboard-table td {
+  padding: 12px 16px;
+  text-align: left;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.dashboard-table th {
+  font-weight: 600;
+  color: #1f2937;
+  position: sticky;
+  top: 0;
+  background: #e2e8f0;
+  z-index: 1;
+}
+
+.dashboard-table th:first-child,
+.dashboard-table td:first-child {
+  position: sticky;
+  left: 0;
+  background: #f8fafc;
+  min-width: 220px;
+  box-shadow: 2px 0 6px rgba(15, 23, 42, 0.05);
+}
+
+.dashboard-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.dashboard-table tbody tr:hover td {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.dashboard-response {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 6px 12px;
+  min-width: 96px;
+  text-align: center;
+}
+
+.dashboard-response.small {
+  padding: 4px 8px;
+  min-width: 72px;
+}
+
+.dashboard-response--yes {
+  background: #d1fae5;
+  color: #047857;
+}
+
+.dashboard-response--rather-yes {
+  background: #fef3c7;
+  color: #c2410c;
+}
+
+.dashboard-response--neutral {
+  background: #e0f2fe;
+  color: #0369a1;
+}
+
+.dashboard-response--rather-no {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.dashboard-response--no {
+  background: #fecdd3;
+  color: #9d174d;
+}
+
+.dashboard-response--empty {
+  background: rgba(148, 163, 184, 0.18);
+  color: #475569;
+}
+
+.dashboard-chart-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
+  background: #ffffff;
+}
+
+.dashboard-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.85rem;
+}
+
+.dashboard-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.05);
+  color: #1f2937;
+}
+
+.dashboard-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.dashboard-chart {
+  width: 100%;
+  height: 260px;
+}
+
+.dashboard-chart text {
+  font-size: 0.8rem;
+  fill: #475569;
+}
+
+.dashboard-chart .chart-axis {
+  stroke: rgba(148, 163, 184, 0.6);
+  stroke-width: 1;
+}
+
+.dashboard-chart .chart-grid {
+  stroke: rgba(148, 163, 184, 0.35);
+  stroke-dasharray: 4 4;
+}
+
+.dashboard-chart .chart-line {
+  fill: none;
+  stroke-width: 2.5;
+}
+
+.dashboard-chart .chart-point {
+  stroke: #ffffff;
+  stroke-width: 2;
+}
+
+.dashboard-empty-message {
+  font-style: italic;
+  color: #64748b;
+}
+
+@media (max-width: 768px) {
+  .dashboard-panel {
+    padding: 20px;
+  }
+
+  .dashboard-table th:first-child,
+  .dashboard-table td:first-child {
+    min-width: 180px;
+  }
+
+  .dashboard-response {
+    font-size: 0.85rem;
+    min-width: 82px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- Ajouter une section "Tableau de bord" avec filtre de période, tableau compact et zone de graphique
- Styliser la nouvelle vue avec colonnes collantes, légende et pastilles de réponse lisibles
- Générer et afficher les données du tableau de bord côté client avec un graphique SVG synchronisé sur le filtre

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5b893c2888333a89c97fe18536015