### PR TITLE
Fix mobile editor toolbar sticky behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -540,6 +540,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   position: sticky;
   top: calc(var(--toolbar-offset) + var(--toolbar-sticky-gap));
   left: 0;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -552,7 +553,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   width: 100%;
-  align-self: stretch;
+  max-width: none;
+  align-self: flex-start;
+  flex-shrink: 0;
   margin-bottom: 0.75rem;
   z-index: 4;
 }
@@ -1102,6 +1105,7 @@ body.notes-drawer-open .drawer-overlay {
     position: sticky;
     top: calc(var(--toolbar-offset) + var(--toolbar-sticky-gap));
     left: 0;
+    right: 0;
     transform: none;
     width: 100%;
     max-width: none;
@@ -1111,7 +1115,8 @@ body.notes-drawer-open .drawer-overlay {
     border-radius: 0.9rem;
     border: 1px solid rgba(15, 23, 42, 0.08);
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15), 0 4px 10px rgba(15, 23, 42, 0.12);
-    align-self: stretch;
+    align-self: flex-start;
+    flex-shrink: 0;
     z-index: 6;
   }
 
@@ -1304,6 +1309,8 @@ body.notes-drawer-open .drawer-overlay {
     padding: 0.4rem 0.55rem;
     gap: 0.35rem;
     border-radius: 0.8rem;
+    align-self: flex-start;
+    flex-shrink: 0;
   }
 
   .toolbar-quick-actions {


### PR DESCRIPTION
## Summary
- ensure the editor toolbar no longer stretches inside flex containers so sticky position is honored on mobile
- add right edge constraint and flex shrink safeguards for the toolbar across responsive breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b9a7d6208333a107acbea3feb15a