### PR TITLE
Refonte de la barre d'outils de l'éditeur

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,9 @@
                   <span id="save-status" class="save-status muted"></span>
                 </div>
               </div>
-              <div class="editor-toolbar" aria-label="Outils de mise en forme">
-                <div class="toolbar-quick-actions" role="toolbar" aria-label="Raccourcis de mise en forme">
-                  <div class="toolbar-group toolbar-group--quick">
+              <div class="editor-toolbar" role="toolbar" aria-label="Outils de mise en forme">
+                <div class="toolbar-row toolbar-row--primary" aria-label="Raccourcis de mise en forme">
+                  <div class="toolbar-group" role="group" aria-label="Styles de texte">
                     <button type="button" class="toolbar-button" data-command="bold" title="Gras (Ctrl+B)">
                       <span class="icon" aria-hidden="true">B</span>
                       <span class="sr-only">Gras</span>
@@ -124,7 +124,7 @@
                       <span class="sr-only">Souligner</span>
                     </button>
                   </div>
-                  <div class="toolbar-group toolbar-group--quick">
+                  <div class="toolbar-group" role="group" aria-label="Listes">
                     <button type="button" class="toolbar-button" data-command="insertUnorderedList" title="Liste à puces">
                       <span class="icon" aria-hidden="true">•</span>
                       <span class="sr-only">Liste à puces</span>
@@ -134,7 +134,7 @@
                       <span class="sr-only">Liste numérotée</span>
                     </button>
                   </div>
-                  <div class="toolbar-group toolbar-group--quick">
+                  <div class="toolbar-group toolbar-group--colors" role="group" aria-label="Couleurs">
                     <button
                       type="button"
                       class="toolbar-button color-tool"
@@ -152,20 +152,8 @@
                       <span class="sr-only">Surligner la sélection</span>
                     </button>
                   </div>
-                  <button
-                    type="button"
-                    class="toolbar-button toolbar-more-button"
-                    id="toolbar-more-btn"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    aria-controls="toolbar-more-panel"
-                    title="Afficher plus d’options"
-                  >
-                    <span class="icon" aria-hidden="true">⋮</span>
-                    <span class="sr-only">Plus d’outils</span>
-                  </button>
                 </div>
-                <div class="toolbar-more-panel" id="toolbar-more-panel">
+                <div class="toolbar-row toolbar-row--secondary" id="toolbar-more-panel" role="group" aria-label="Options avancées">
                   <div class="toolbar-group toolbar-group--primary">
                     <label class="toolbar-select">
                       <span class="sr-only">Style de texte</span>

--- a/styles.css
+++ b/styles.css
@@ -537,20 +537,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor-toolbar {
-  position: -webkit-sticky;
   position: sticky;
-  top: calc(
-    var(--toolbar-offset, var(--header-height, 0px)) +
-      var(--toolbar-sticky-gap, 0.5rem) +
-      env(safe-area-inset-top, 0px)
-  );
-  left: 0;
-  right: 0;
+  top: calc(var(--header-height, 0px) + env(safe-area-inset-top, 0px));
+  z-index: 24;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
   gap: 0.75rem;
-  padding: 0.6rem 0.75rem;
+  padding: 0.75rem 1rem;
   background: var(--editor-toolbar-surface);
   border-radius: 0.85rem;
   border: 1px solid rgba(15, 23, 42, 0.08);
@@ -558,66 +551,33 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
   width: 100%;
-  max-width: none;
   align-self: flex-start;
-  flex-shrink: 0;
-  margin-bottom: 0.75rem;
-  z-index: 4;
+  margin-bottom: 1rem;
 }
 
-.toolbar-quick-actions {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-}
-
-.toolbar-more-button {
-  margin-left: auto;
-  display: none;
-  min-width: 2.5rem;
-  min-height: 2.5rem;
-  padding: 0.35rem;
-}
-
-.toolbar-more-button .icon {
-  font-size: 1.2rem;
-}
-
-.toolbar-more-panel {
+.toolbar-row {
   display: flex;
   align-items: center;
   gap: 0.75rem;
-  flex: 1 1 auto;
   flex-wrap: wrap;
+}
+
+.toolbar-row--secondary {
+  padding-top: 0.5rem;
+  margin-top: 0.35rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .toolbar-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
-  padding-right: 0.75rem;
-  margin-right: 0.75rem;
-  border-right: 1px solid var(--border);
-  flex-wrap: wrap;
-}
-
-.toolbar-group:last-child {
-  border-right: none;
-  margin-right: 0;
-  padding-right: 0;
-}
-
-.toolbar-group--quick {
-  border-right: none;
-  margin-right: 0;
-  padding-right: 0;
   gap: 0.45rem;
+  flex-wrap: wrap;
 }
 
 .toolbar-group--primary {
   flex: 1 1 320px;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 
 .toolbar-group--primary > .toolbar-select {
@@ -625,7 +585,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .toolbar-group--primary > .font-size-control {
-  flex: 1 1 140px;
+  flex: 1 1 150px;
   justify-content: space-between;
 }
 
@@ -1106,129 +1066,45 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    position: -webkit-sticky;
-    position: sticky;
-    top: calc(
-      var(--toolbar-offset, var(--header-height, 0px)) +
-        var(--toolbar-sticky-gap, 0.5rem) +
-        env(safe-area-inset-top, 0px)
-    );
-    left: 0;
-    right: 0;
-    transform: none;
-    width: 100%;
-    max-width: none;
-    margin: 0;
-    padding: 0.5rem 0.65rem;
-    gap: 0.45rem;
-    border-radius: 0.9rem;
-    border: 1px solid rgba(15, 23, 42, 0.08);
+    padding: 0.6rem 0.75rem;
+    gap: 0.6rem;
     box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15), 0 4px 10px rgba(15, 23, 42, 0.12);
-    align-self: flex-start;
-    flex-shrink: 0;
-    z-index: 6;
   }
 
-  .toolbar-quick-actions {
+  .toolbar-row {
     width: 100%;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-    justify-content: flex-start;
+    gap: 0.6rem;
   }
 
   .toolbar-group {
-    border: none;
-    margin-right: 0;
-    padding-right: 0;
-    width: auto;
-  }
-
-  .toolbar-group--quick {
-    flex: 1 1 auto;
+    width: 100%;
     justify-content: flex-start;
-    gap: 0.3rem;
   }
 
-  .toolbar-group--quick .toolbar-button {
-    min-width: 2.4rem;
-    min-height: 2.4rem;
-    font-size: 1.05rem;
-    padding: 0.4rem;
+  .toolbar-group.toolbar-group--colors {
+    justify-content: flex-start;
   }
 
-  .toolbar-more-button {
-    display: inline-flex;
-    margin-left: auto;
-    min-width: 2.6rem;
-    min-height: 2.6rem;
-  }
-
-  .toolbar-more-panel {
-    display: none;
-    width: 100%;
-    flex-direction: column;
-    gap: 0.55rem;
-    background: rgba(248, 250, 252, 0.96);
-    border: 1px solid rgba(15, 23, 42, 0.08);
-    border-radius: 0.75rem;
-    padding: 0.65rem 0.7rem;
-    box-shadow: 0 10px 22px rgba(15, 23, 42, 0.18), 0 4px 10px rgba(15, 23, 42, 0.1);
-    margin-top: 0.35rem;
-  }
-
-  .toolbar-more-panel.is-open {
-    display: flex;
-  }
-
-  .toolbar-more-panel .toolbar-group {
-    width: 100%;
-    border: none;
-    margin: 0;
-    padding: 0;
+  .toolbar-group--primary {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.4rem;
-  }
-
-  .toolbar-more-panel .toolbar-group.toolbar-group--primary {
     gap: 0.5rem;
   }
 
-  .toolbar-more-panel .toolbar-group.toolbar-group--primary > .toolbar-select,
-  .toolbar-more-panel .toolbar-group.toolbar-group--primary > .font-size-control {
+  .toolbar-group--primary > .toolbar-select,
+  .toolbar-group--primary > .font-size-control {
     flex: 1 1 auto;
     width: 100%;
   }
 
-  .toolbar-more-panel .toolbar-select {
-    min-height: 2rem;
-    padding: 0 0.5rem;
-  }
-
-  .toolbar-more-panel .toolbar-select select {
-    font-size: 0.92rem;
-  }
-
-  .toolbar-more-panel .font-size-control {
-    min-height: 2rem;
-    padding: 0.2rem 0.35rem;
-    gap: 0.3rem;
-  }
-
-  .toolbar-more-panel .font-size-control #font-size-value {
-    font-size: 0.92rem;
-  }
-
-  .toolbar-more-panel .toolbar-group .toolbar-button {
+  .toolbar-group--advanced {
     width: 100%;
-    justify-content: center;
-    min-height: 2.1rem;
-    padding: 0.35rem 0.5rem;
-    font-size: 0.92rem;
+    justify-content: flex-start;
   }
 
-  .toolbar-more-panel .toolbar-group .toolbar-button .icon {
-    font-size: 0.92rem;
+  .toolbar-row--secondary {
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+    padding-top: 0.6rem;
   }
 
   .editor-header {
@@ -1242,7 +1118,7 @@ body.notes-drawer-open .drawer-overlay {
     flex: 1 1 140px;
   }
 
-  .toolbar-more-panel .toolbar-select {
+  #toolbar-more-panel .toolbar-select {
     min-width: 0;
   }
 
@@ -1322,24 +1198,18 @@ body.notes-drawer-open .drawer-overlay {
     flex-shrink: 0;
   }
 
-  .toolbar-quick-actions {
-    gap: 0.25rem;
+  .toolbar-row {
+    gap: 0.45rem;
   }
 
-  .toolbar-group--quick {
-    gap: 0.18rem;
+  .toolbar-group {
+    gap: 0.35rem;
   }
 
-  .toolbar-group--quick .toolbar-button {
+  .toolbar-group .toolbar-button {
     min-width: 2.05rem;
     min-height: 2.05rem;
     font-size: 0.95rem;
-  }
-
-  .toolbar-more-panel {
-    padding: 0.5rem 0.6rem;
-    gap: 0.45rem;
-    border-radius: 0.65rem;
   }
 
   .toolbar-select {


### PR DESCRIPTION
## Summary
- replace the editor toolbar markup with a simplified two-row structure while keeping existing formatting controls
- update the toolbar styling so it sticks beneath the app header and adapts across breakpoints

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5c1074c8083339fe1057dbc5edfe0