### PR TITLE
Améliore la réactivité de la barre d'outils mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1200,10 +1200,33 @@ body.notes-drawer-open .drawer-overlay {
 
   .toolbar-row {
     gap: 0.45rem;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0.15rem;
+    margin: 0 -0.2rem;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .toolbar-row::-webkit-scrollbar {
+    display: none;
   }
 
   .toolbar-group {
     gap: 0.35rem;
+    width: auto;
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
+
+  .toolbar-group.toolbar-group--primary {
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: nowrap;
+  }
+
+  .toolbar-group.toolbar-group--advanced {
+    flex-wrap: nowrap;
   }
 
   .toolbar-group .toolbar-button {
@@ -1213,7 +1236,17 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-select {
-    min-width: 0;
+    min-width: 120px;
+    flex: 0 0 auto;
+  }
+
+  .toolbar-select select {
+    font-size: 0.9rem;
+  }
+
+  .font-size-control {
+    min-width: 110px;
+    flex: 0 0 auto;
   }
 
   .editor {


### PR DESCRIPTION
## Summary
- ajusted the editor toolbar layout on narrow screens to keep groups inline and scrollable
- tuned select and font size controls to maintain compact sizing on phones
- hid horizontal scrollbars and enabled touch-friendly snapping for toolbar groups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5c32812248333849efef16eb6d920