### PR TITLE
Fusion de la barre d'outils avec l'en-tête principal

### DIFF
--- a/app.js
+++ b/app.js
@@ -633,6 +633,10 @@ function bootstrapApp() {
     state.isEditorFocused = false;
     state.savedSelection = null;
     state[CLOZE_MANUAL_REVEAL_SET_KEY] = new WeakSet();
+    if (headerElement) {
+      headerElement.classList.add("toolbar-hidden");
+    }
+    setToolbarMoreMenu(false);
     if (ui.blockFormat) {
       ui.blockFormat.value = "p";
     }
@@ -652,6 +656,9 @@ function bootstrapApp() {
     hideClozeFeedback();
     ui.emptyState.classList.add("hidden");
     ui.editorWrapper.classList.remove("hidden");
+    if (headerElement) {
+      headerElement.classList.remove("toolbar-hidden");
+    }
     const desiredTitle = state.currentNote.title || "";
     if (force || ui.noteTitle.value !== desiredTitle) {
       ui.noteTitle.value = desiredTitle;

--- a/index.html
+++ b/index.html
@@ -14,38 +14,147 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="app-header">
-      <div class="brand">
-        <button
-          type="button"
-          id="mobile-notes-btn"
-          class="header-icon-button"
-          aria-label="Afficher les fiches"
-          aria-pressed="false"
-          aria-expanded="true"
-        >
-          ☰
-          <span class="sr-only">Afficher les fiches</span>
-        </button>
-        <div class="brand-text">
-          <h1>Apprentissage actif</h1>
-          <p class="subtitle">Des fiches simples, prêtes à apprendre.</p>
+    <header class="app-header toolbar-hidden">
+      <div class="header-top">
+        <div class="brand">
+          <button
+            type="button"
+            id="mobile-notes-btn"
+            class="header-icon-button"
+            aria-label="Afficher les fiches"
+            aria-pressed="false"
+            aria-expanded="true"
+          >
+            ☰
+            <span class="sr-only">Afficher les fiches</span>
+          </button>
+          <div class="brand-text">
+            <h1>Apprentissage actif</h1>
+            <p class="subtitle">Des fiches simples, prêtes à apprendre.</p>
+          </div>
+        </div>
+        <div class="header-actions">
+          <span id="current-user" class="muted"></span>
+          <button
+            type="button"
+            id="workspace-menu-btn"
+            class="header-menu-toggle"
+            aria-haspopup="true"
+            aria-expanded="false"
+            aria-label="Ouvrir le menu principal"
+          >
+            ⋮
+          </button>
+          <div id="workspace-menu" class="header-menu" role="menu">
+            <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
+          </div>
         </div>
       </div>
-      <div class="header-actions">
-        <span id="current-user" class="muted"></span>
-        <button
-          type="button"
-          id="workspace-menu-btn"
-          class="header-menu-toggle"
-          aria-haspopup="true"
-          aria-expanded="false"
-          aria-label="Ouvrir le menu principal"
-        >
-          ⋮
-        </button>
-        <div id="workspace-menu" class="header-menu" role="menu">
-          <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
+      <div class="header-toolbar">
+        <div class="editor-toolbar" role="toolbar" aria-label="Outils de mise en forme">
+          <div class="toolbar-row toolbar-row--primary" aria-label="Raccourcis de mise en forme">
+            <div class="toolbar-group" role="group" aria-label="Styles de texte">
+              <button type="button" class="toolbar-button" data-command="bold" title="Gras (Ctrl+B)">
+                <span class="icon" aria-hidden="true">B</span>
+                <span class="sr-only">Gras</span>
+              </button>
+              <button type="button" class="toolbar-button" data-command="italic" title="Italique (Ctrl+I)">
+                <span class="icon" aria-hidden="true">I</span>
+                <span class="sr-only">Italique</span>
+              </button>
+              <button type="button" class="toolbar-button" data-command="underline" title="Souligné (Ctrl+U)">
+                <span class="icon" aria-hidden="true">U</span>
+                <span class="sr-only">Souligner</span>
+              </button>
+            </div>
+            <div class="toolbar-group" role="group" aria-label="Listes">
+              <button type="button" class="toolbar-button" data-command="insertUnorderedList" title="Liste à puces">
+                <span class="icon" aria-hidden="true">•</span>
+                <span class="sr-only">Liste à puces</span>
+              </button>
+              <button type="button" class="toolbar-button" data-command="insertOrderedList" title="Liste numérotée">
+                <span class="icon" aria-hidden="true">1.</span>
+                <span class="sr-only">Liste numérotée</span>
+              </button>
+            </div>
+            <div class="toolbar-group toolbar-group--colors" role="group" aria-label="Couleurs">
+              <button
+                type="button"
+                class="toolbar-button color-tool"
+                data-action="applyTextColor"
+                data-value="#1f2937"
+                title="Couleur du texte"
+              >
+                <span class="icon" aria-hidden="true">A</span>
+                <span class="color-bar" aria-hidden="true"></span>
+                <span class="sr-only">Appliquer la couleur du texte</span>
+              </button>
+              <button type="button" class="toolbar-button color-tool" data-action="applyHighlight" title="Surligner">
+                <span class="icon" aria-hidden="true">🖍</span>
+                <span class="color-bar highlight" aria-hidden="true"></span>
+                <span class="sr-only">Surligner la sélection</span>
+              </button>
+            </div>
+            <button
+              type="button"
+              id="toolbar-more-btn"
+              class="toolbar-button toolbar-more-toggle"
+              aria-expanded="false"
+              aria-controls="toolbar-more-panel"
+              title="Afficher plus d'options"
+            >
+              ⋯
+              <span class="sr-only">Afficher plus d'options</span>
+            </button>
+          </div>
+          <div
+            class="toolbar-row toolbar-row--secondary"
+            id="toolbar-more-panel"
+            role="group"
+            aria-label="Options avancées"
+            aria-hidden="true"
+          >
+            <div class="toolbar-group toolbar-group--primary">
+              <label class="toolbar-select">
+                <span class="sr-only">Style de texte</span>
+                <select id="block-format" data-command="formatBlock" aria-label="Style de texte">
+                  <option value="p" selected>Normal</option>
+                  <option value="h1">Titre 1</option>
+                  <option value="h2">Titre 2</option>
+                  <option value="h3">Titre 3</option>
+                  <option value="blockquote">Citation</option>
+                </select>
+              </label>
+              <label class="toolbar-select">
+                <span class="sr-only">Police</span>
+                <select id="font-family" data-command="fontName" aria-label="Police">
+                  <option value="Arial" selected>Arial</option>
+                  <option value="Georgia">Georgia</option>
+                  <option value="Inter">Inter</option>
+                  <option value="Times New Roman">Times New Roman</option>
+                  <option value="Trebuchet MS">Trebuchet</option>
+                  <option value="Verdana">Verdana</option>
+                </select>
+              </label>
+              <div class="font-size-control" role="group" aria-label="Taille du texte">
+                <button type="button" class="toolbar-button" data-action="decreaseFontSize" title="Diminuer la taille">
+                  <span aria-hidden="true">−</span>
+                  <span class="sr-only">Diminuer la taille</span>
+                </button>
+                <span id="font-size-value" aria-live="polite">11</span>
+                <button type="button" class="toolbar-button" data-action="increaseFontSize" title="Augmenter la taille">
+                  <span aria-hidden="true">+</span>
+                  <span class="sr-only">Augmenter la taille</span>
+                </button>
+              </div>
+            </div>
+            <div class="toolbar-group toolbar-group--advanced">
+              <button type="button" class="toolbar-button" data-command="removeFormat" title="Effacer la mise en forme">
+                <span class="icon" aria-hidden="true">⨯</span>
+                <span class="sr-only">Effacer la mise en forme</span>
+              </button>
+            </div>
+          </div>
         </div>
       </div>
     </header>

--- a/styles.css
+++ b/styles.css
@@ -134,14 +134,32 @@ input[type="text"]:focus {
   top: 0;
   z-index: 30;
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.75rem 1.5rem;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1.5rem 0.65rem;
   background: #ffffff;
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
   transition: top 0.25s ease, box-shadow 0.2s ease;
+}
+
+.header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-content: center;
+}
+
+.header-toolbar {
+  border-top: 1px solid rgba(60, 64, 67, 0.16);
+  padding-top: 0.35rem;
+  margin-top: 0.1rem;
+}
+
+.app-header.toolbar-hidden .header-toolbar {
+  display: none;
 }
 
 .brand h1 {
@@ -270,6 +288,10 @@ body.header-collapsed .app-header {
   padding: 0;
   border-bottom: none;
   box-shadow: none;
+}
+
+body.header-collapsed .header-toolbar {
+  display: none !important;
 }
 
 body.header-collapsed .brand-text,
@@ -506,7 +528,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-wrapper {
   display: grid;
-  grid-template-rows: auto auto minmax(0, 1fr);
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 1rem;
   flex: 1 1 auto;
   height: 100%;
@@ -537,35 +559,29 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor-toolbar {
-  position: sticky;
-  top: calc(var(--header-height, 0px) + env(safe-area-inset-top, 0px));
-  z-index: 24;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  background: var(--editor-toolbar-surface);
-  border-radius: 0.85rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.14), 0 6px 12px rgba(15, 23, 42, 0.12);
-  backdrop-filter: blur(14px);
-  -webkit-backdrop-filter: blur(14px);
+  gap: 0.45rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
   width: 100%;
-  align-self: flex-start;
-  margin-bottom: 1rem;
 }
 
 .toolbar-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.55rem;
   flex-wrap: wrap;
 }
 
 .toolbar-row--secondary {
-  padding-top: 0.5rem;
-  margin-top: 0.35rem;
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding-top: 0.35rem;
+  margin-top: 0.2rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.12);
 }
 
 .toolbar-group {
@@ -577,7 +593,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .toolbar-group--primary {
   flex: 1 1 320px;
-  gap: 0.6rem;
+  gap: 0.5rem;
 }
 
 .toolbar-group--primary > .toolbar-select {
@@ -600,8 +616,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   background: #f8f9fa;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  padding: 0 0.55rem;
-  min-height: 2.1rem;
+  padding: 0 0.5rem;
+  min-height: 2rem;
   min-width: 140px;
   box-shadow: none;
 }
@@ -620,8 +636,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .toolbar-select select {
   border: none;
   background: transparent;
-  padding: 0 1.5rem 0 0;
-  font-size: 0.95rem;
+  padding: 0 1.4rem 0 0;
+  font-size: 0.92rem;
   color: var(--fg);
   appearance: none;
   width: 100%;
@@ -638,8 +654,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   background: #f8f9fa;
   border: 1px solid var(--border);
   border-radius: 0.5rem;
-  padding: 0.25rem 0.45rem;
-  min-height: 2.1rem;
+  padding: 0.2rem 0.4rem;
+  min-height: 2rem;
   box-shadow: none;
 }
 
@@ -656,15 +672,15 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-radius: 0.55rem;
   border: 1px solid transparent;
   color: var(--fg);
-  padding: 0.35rem 0.55rem;
-  min-width: 2.45rem;
-  min-height: 2.45rem;
+  padding: 0.3rem 0.5rem;
+  min-width: 2.2rem;
+  min-height: 2.2rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   box-shadow: none;
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-  font-size: 0.95rem;
+  font-size: 0.92rem;
 }
 
 .editor-toolbar .toolbar-button:hover {
@@ -699,7 +715,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-toolbar .color-tool {
   position: relative;
-  padding-bottom: 0.55rem;
+  padding-bottom: 0.45rem;
 }
 
 .editor-toolbar .color-tool .color-bar {
@@ -725,8 +741,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .font-size-control .toolbar-button {
-  min-width: 1.8rem;
-  height: 1.8rem;
+  min-width: 1.7rem;
+  height: 1.7rem;
 }
 
 .editor {
@@ -1073,14 +1089,14 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    padding: 0.6rem 0.75rem;
-    gap: 0.6rem;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15), 0 4px 10px rgba(15, 23, 42, 0.12);
+    padding: 0;
+    gap: 0.45rem;
+    box-shadow: none;
   }
 
   .toolbar-row {
     width: 100%;
-    gap: 0.6rem;
+    gap: 0.5rem;
   }
 
   .toolbar-group {
@@ -1110,8 +1126,8 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-row--secondary {
-    border-top: 1px solid rgba(15, 23, 42, 0.08);
-    padding-top: 0.6rem;
+    border-top: 1px solid rgba(15, 23, 42, 0.12);
+    padding-top: 0.45rem;
   }
 
   .editor-header {
@@ -1198,14 +1214,14 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    padding: 0.4rem 0.55rem;
+    padding: 0;
     gap: 0.35rem;
-    border-radius: 0.8rem;
+    border-radius: 0;
     align-self: flex-start;
     flex-shrink: 0;
-    border: 1px solid rgba(15, 23, 42, 0.05);
-    box-shadow: 0 8px 18px rgba(15, 23, 42, 0.12), 0 3px 8px rgba(15, 23, 42, 0.08);
-    margin-bottom: 0.75rem;
+    border: none;
+    box-shadow: none;
+    margin-bottom: 0;
   }
 
   .editor-toolbar .toolbar-more-toggle {
@@ -1215,8 +1231,8 @@ body.notes-drawer-open .drawer-overlay {
     background: transparent;
     border: 1px solid rgba(15, 23, 42, 0.12);
     color: var(--muted);
-    min-width: 2.2rem;
-    min-height: 2.2rem;
+    min-width: 2.1rem;
+    min-height: 2.1rem;
     box-shadow: none;
   }
 
@@ -1276,9 +1292,9 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .toolbar-group .toolbar-button {
-    min-width: 2.05rem;
-    min-height: 2.05rem;
-    font-size: 0.95rem;
+    min-width: 2rem;
+    min-height: 2rem;
+    font-size: 0.9rem;
   }
 
   .toolbar-select {


### PR DESCRIPTION
## Summary
- intègre la barre d’outils de mise en forme dans l’en-tête principal tout en conservant le titre de fiche dans le corps
- condense la présentation de la barre d’outils et ajuste les styles réactifs pour la nouvelle disposition
- met à jour la logique d’interface pour masquer ou afficher la barre d’outils selon l’état de l’éditeur

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d64ed13b088333a0aaab7ae3974cf8