### PR TITLE
Condense header toolbar layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,6 @@
           </div>
         </div>
         <div class="header-actions">
-          <span id="current-user" class="muted"></span>
           <button
             type="button"
             id="workspace-menu-btn"
@@ -46,6 +45,9 @@
             ⋮
           </button>
           <div id="workspace-menu" class="header-menu" role="menu">
+            <p class="menu-meta" role="none">
+              Connecté en tant que <span id="current-user" class="menu-meta-strong"></span>
+            </p>
             <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
           </div>
         </div>
@@ -215,111 +217,6 @@
                     aria-label="Titre de la fiche"
                   />
                   <span id="save-status" class="save-status muted"></span>
-                </div>
-              </div>
-              <div class="editor-toolbar" role="toolbar" aria-label="Outils de mise en forme">
-                <div class="toolbar-row toolbar-row--primary" aria-label="Raccourcis de mise en forme">
-                  <div class="toolbar-group" role="group" aria-label="Styles de texte">
-                    <button type="button" class="toolbar-button" data-command="bold" title="Gras (Ctrl+B)">
-                      <span class="icon" aria-hidden="true">B</span>
-                      <span class="sr-only">Gras</span>
-                    </button>
-                    <button type="button" class="toolbar-button" data-command="italic" title="Italique (Ctrl+I)">
-                      <span class="icon" aria-hidden="true">I</span>
-                      <span class="sr-only">Italique</span>
-                    </button>
-                    <button type="button" class="toolbar-button" data-command="underline" title="Souligné (Ctrl+U)">
-                      <span class="icon" aria-hidden="true">U</span>
-                      <span class="sr-only">Souligner</span>
-                    </button>
-                  </div>
-                  <div class="toolbar-group" role="group" aria-label="Listes">
-                    <button type="button" class="toolbar-button" data-command="insertUnorderedList" title="Liste à puces">
-                      <span class="icon" aria-hidden="true">•</span>
-                      <span class="sr-only">Liste à puces</span>
-                    </button>
-                    <button type="button" class="toolbar-button" data-command="insertOrderedList" title="Liste numérotée">
-                      <span class="icon" aria-hidden="true">1.</span>
-                      <span class="sr-only">Liste numérotée</span>
-                    </button>
-                  </div>
-                  <div class="toolbar-group toolbar-group--colors" role="group" aria-label="Couleurs">
-                    <button
-                      type="button"
-                      class="toolbar-button color-tool"
-                      data-action="applyTextColor"
-                      data-value="#1f2937"
-                      title="Couleur du texte"
-                    >
-                      <span class="icon" aria-hidden="true">A</span>
-                      <span class="color-bar" aria-hidden="true"></span>
-                      <span class="sr-only">Appliquer la couleur du texte</span>
-                    </button>
-                    <button type="button" class="toolbar-button color-tool" data-action="applyHighlight" title="Surligner">
-                      <span class="icon" aria-hidden="true">🖍</span>
-                      <span class="color-bar highlight" aria-hidden="true"></span>
-                      <span class="sr-only">Surligner la sélection</span>
-                    </button>
-                  </div>
-                  <button
-                    type="button"
-                    id="toolbar-more-btn"
-                    class="toolbar-button toolbar-more-toggle"
-                    aria-expanded="false"
-                    aria-controls="toolbar-more-panel"
-                    title="Afficher plus d'options"
-                  >
-                    ⋯
-                    <span class="sr-only">Afficher plus d'options</span>
-                  </button>
-                </div>
-                <div
-                  class="toolbar-row toolbar-row--secondary"
-                  id="toolbar-more-panel"
-                  role="group"
-                  aria-label="Options avancées"
-                  aria-hidden="true"
-                >
-                  <div class="toolbar-group toolbar-group--primary">
-                    <label class="toolbar-select">
-                      <span class="sr-only">Style de texte</span>
-                      <select id="block-format" data-command="formatBlock" aria-label="Style de texte">
-                        <option value="p" selected>Normal</option>
-                        <option value="h1">Titre 1</option>
-                        <option value="h2">Titre 2</option>
-                        <option value="h3">Titre 3</option>
-                        <option value="blockquote">Citation</option>
-                      </select>
-                    </label>
-                    <label class="toolbar-select">
-                      <span class="sr-only">Police</span>
-                      <select id="font-family" data-command="fontName" aria-label="Police">
-                        <option value="Arial" selected>Arial</option>
-                        <option value="Georgia">Georgia</option>
-                        <option value="Inter">Inter</option>
-                        <option value="Times New Roman">Times New Roman</option>
-                        <option value="Trebuchet MS">Trebuchet</option>
-                        <option value="Verdana">Verdana</option>
-                      </select>
-                    </label>
-                    <div class="font-size-control" role="group" aria-label="Taille du texte">
-                      <button type="button" class="toolbar-button" data-action="decreaseFontSize" title="Diminuer la taille">
-                        <span aria-hidden="true">−</span>
-                        <span class="sr-only">Diminuer la taille</span>
-                      </button>
-                      <span id="font-size-value" aria-live="polite">11</span>
-                      <button type="button" class="toolbar-button" data-action="increaseFontSize" title="Augmenter la taille">
-                        <span aria-hidden="true">+</span>
-                        <span class="sr-only">Augmenter la taille</span>
-                      </button>
-                    </div>
-                  </div>
-                  <div class="toolbar-group toolbar-group--advanced">
-                    <button type="button" class="toolbar-button" data-command="removeFormat" title="Effacer la mise en forme">
-                      <span class="icon" aria-hidden="true">⨯</span>
-                      <span class="sr-only">Effacer la mise en forme</span>
-                    </button>
-                  </div>
                 </div>
               </div>
               <div

--- a/styles.css
+++ b/styles.css
@@ -132,11 +132,11 @@ input[type="text"]:focus {
 .app-header {
   position: sticky;
   top: 0;
-  z-index: 30;
+  z-index: 100;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.75rem 1.5rem 0.65rem;
+  gap: 0.25rem;
+  padding: 0.5rem 1.25rem 0.35rem;
   background: #ffffff;
   border-bottom: 1px solid var(--border);
   box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
@@ -147,15 +147,15 @@ input[type="text"]:focus {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   flex-wrap: wrap;
   align-content: center;
 }
 
 .header-toolbar {
-  border-top: 1px solid rgba(60, 64, 67, 0.16);
-  padding-top: 0.35rem;
-  margin-top: 0.1rem;
+  border-top: 1px solid rgba(60, 64, 67, 0.12);
+  padding-top: 0.2rem;
+  margin-top: 0;
 }
 
 .app-header.toolbar-hidden .header-toolbar {
@@ -170,7 +170,7 @@ input[type="text"]:focus {
 .brand {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
 }
 
 .brand-text {
@@ -182,14 +182,14 @@ input[type="text"]:focus {
 }
 
 .subtitle {
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   color: var(--muted);
   margin-top: 0.15rem;
 }
 
 .header-icon-button {
-  width: 2.25rem;
-  height: 2.25rem;
+  width: 2rem;
+  height: 2rem;
   border-radius: 999px;
   border: none;
   background: transparent;
@@ -215,13 +215,13 @@ input[type="text"]:focus {
 .header-actions {
   display: inline-flex;
   align-items: center;
-  gap: 0.65rem;
+  gap: 0.45rem;
   position: relative;
 }
 
 .header-menu-toggle {
-  width: 2rem;
-  height: 2rem;
+  width: 1.9rem;
+  height: 1.9rem;
   border-radius: 999px;
   background: transparent;
   color: var(--muted);
@@ -270,6 +270,21 @@ input[type="text"]:focus {
   background: transparent;
   color: var(--fg);
   box-shadow: none;
+}
+
+.header-menu .menu-meta {
+  margin: 0 0 0.3rem;
+  padding: 0.45rem 0.75rem 0.55rem;
+  font-size: 0.85rem;
+  color: var(--muted);
+  border-bottom: 1px solid rgba(60, 64, 67, 0.12);
+}
+
+.header-menu .menu-meta-strong {
+  display: inline-block;
+  margin-left: 0.2rem;
+  color: var(--fg);
+  font-weight: 600;
 }
 
 .header-menu .menu-item:hover {
@@ -561,7 +576,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .editor-toolbar {
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
+  gap: 0.35rem;
   padding: 0;
   background: transparent;
   border: none;
@@ -574,26 +589,26 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .toolbar-row {
   display: flex;
   align-items: center;
-  gap: 0.55rem;
+  gap: 0.45rem;
   flex-wrap: wrap;
 }
 
 .toolbar-row--secondary {
-  padding-top: 0.35rem;
-  margin-top: 0.2rem;
+  padding-top: 0.25rem;
+  margin-top: 0.15rem;
   border-top: 1px solid rgba(15, 23, 42, 0.12);
 }
 
 .toolbar-group {
   display: inline-flex;
   align-items: center;
-  gap: 0.45rem;
+  gap: 0.35rem;
   flex-wrap: wrap;
 }
 
 .toolbar-group--primary {
   flex: 1 1 320px;
-  gap: 0.5rem;
+  gap: 0.4rem;
 }
 
 .toolbar-group--primary > .toolbar-select {
@@ -615,9 +630,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   align-items: center;
   background: #f8f9fa;
   border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  padding: 0 0.5rem;
-  min-height: 2rem;
+  border-radius: 0.45rem;
+  padding: 0 0.45rem;
+  min-height: 1.9rem;
   min-width: 140px;
   box-shadow: none;
 }
@@ -637,7 +652,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border: none;
   background: transparent;
   padding: 0 1.4rem 0 0;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   color: var(--fg);
   appearance: none;
   width: 100%;
@@ -650,12 +665,12 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .font-size-control {
   display: inline-flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: 0.3rem;
   background: #f8f9fa;
   border: 1px solid var(--border);
-  border-radius: 0.5rem;
-  padding: 0.2rem 0.4rem;
-  min-height: 2rem;
+  border-radius: 0.45rem;
+  padding: 0.2rem 0.35rem;
+  min-height: 1.9rem;
   box-shadow: none;
 }
 
@@ -669,18 +684,18 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-toolbar .toolbar-button {
   background: #f8f9fa;
-  border-radius: 0.55rem;
+  border-radius: 0.5rem;
   border: 1px solid transparent;
   color: var(--fg);
-  padding: 0.3rem 0.5rem;
-  min-width: 2.2rem;
-  min-height: 2.2rem;
+  padding: 0.28rem 0.45rem;
+  min-width: 2rem;
+  min-height: 2rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   box-shadow: none;
   transition: border-color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
 }
 
 .editor-toolbar .toolbar-button:hover {


### PR DESCRIPTION
## Summary
- move the “Connecté en tant que …” message into the workspace menu and keep the top bar sticky
- remove the duplicate editor toolbar under the note title so editing tools live in the compact header
- tighten spacing and sizing within the header toolbar for a more condensed presentation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6538580788333887d407179086c25