### PR TITLE
Keep header visible while scrolling

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,22 +250,16 @@ function bootstrapApp() {
   }
   window.addEventListener("orientationchange", updateToolbarOffsets, { passive: true });
 
-  const SCROLL_COLLAPSE_THRESHOLD = 24;
-
-  function updateHeaderCollapseState() {
+  function keepHeaderVisible() {
     if (!bodyElement) {
       return;
     }
 
-    if (window.scrollY > SCROLL_COLLAPSE_THRESHOLD) {
-      bodyElement.classList.add("header-collapsed");
-    } else {
-      bodyElement.classList.remove("header-collapsed");
-    }
+    bodyElement.classList.remove("header-collapsed");
   }
 
-  window.addEventListener("scroll", updateHeaderCollapseState, { passive: true });
-  updateHeaderCollapseState();
+  window.addEventListener("scroll", keepHeaderVisible, { passive: true });
+  keepHeaderVisible();
 
 
   showView(null);


### PR DESCRIPTION
## Summary
- prevent the workspace header from collapsing on scroll so the formatting toolbar stays sticky

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d658fad7648333932ea76af7db6d38