### PR TITLE
Add toolbar actions for cloze creation and iteration

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,26 @@
                 <span class="sr-only">Surligner la sélection</span>
               </button>
             </div>
+            <div class="toolbar-group toolbar-group--actions" role="group" aria-label="Outils d'apprentissage">
+              <button
+                type="button"
+                class="toolbar-button"
+                data-action="createCloze"
+                title="Créer un texte à trous"
+              >
+                <span class="icon" aria-hidden="true">⧉</span>
+                <span class="sr-only">Créer un texte à trous</span>
+              </button>
+              <button
+                type="button"
+                class="toolbar-button"
+                data-action="startIteration"
+                title="Lancer une itération"
+              >
+                <span class="icon" aria-hidden="true">▶</span>
+                <span class="sr-only">Lancer une itération</span>
+              </button>
+            </div>
             <button
               type="button"
               id="toolbar-more-btn"

--- a/styles.css
+++ b/styles.css
@@ -611,6 +611,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   gap: 0.4rem;
 }
 
+.toolbar-group--actions {
+  gap: 0.35rem;
+}
+
 .toolbar-group--primary > .toolbar-select {
   flex: 1 1 180px;
 }
@@ -719,6 +723,12 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor-toolbar .toolbar-button[data-command="underline"] .icon {
   text-decoration: underline;
+}
+
+.editor-toolbar .toolbar-button[data-action="createCloze"] .icon,
+.editor-toolbar .toolbar-button[data-action="startIteration"] .icon {
+  font-size: 0.95rem;
+  font-weight: 600;
 }
 
 .editor-toolbar .toolbar-more-toggle {
@@ -1123,6 +1133,10 @@ body.notes-drawer-open .drawer-overlay {
     justify-content: flex-start;
   }
 
+  .toolbar-group.toolbar-group--actions {
+    justify-content: flex-start;
+  }
+
   .toolbar-group--primary {
     flex-direction: column;
     align-items: stretch;
@@ -1288,6 +1302,10 @@ body.notes-drawer-open .drawer-overlay {
   .toolbar-group.toolbar-group--primary {
     flex-direction: row;
     align-items: center;
+    flex-wrap: nowrap;
+  }
+
+  .toolbar-group.toolbar-group--actions {
     flex-wrap: nowrap;
   }
 


### PR DESCRIPTION
## Summary
- add create cloze and start iteration controls to the primary editor toolbar with appropriate data-action attributes
- style the new toolbar group to align with existing toolbar spacing and icon treatments across responsive breakpoints

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d65cbac0c883338a45d1be3f73386b