### PR TITLE
Handle cloze feedback on window resize

### DIFF
--- a/app.js
+++ b/app.js
@@ -1416,6 +1416,15 @@ function bootstrapApp() {
     clearActiveCloze();
   }
 
+  function handleWindowResize() {
+    if (state.activeCloze) {
+      positionClozeFeedback(state.activeCloze);
+      requestAnimationFrame(() => positionClozeFeedback(state.activeCloze));
+      return;
+    }
+    hideClozeFeedback();
+  }
+
   function positionClozeFeedback(target) {
     if (!ui.clozeFeedback || !target) return;
     const wrapperRect = ui.editorWrapper.getBoundingClientRect();
@@ -1849,7 +1858,7 @@ function bootstrapApp() {
     }
     document.addEventListener("click", handleDocumentClick);
     document.addEventListener("selectionchange", handleSelectionChange);
-    window.addEventListener("resize", hideClozeFeedback);
+    window.addEventListener("resize", handleWindowResize);
     window.addEventListener("beforeunload", (event) => {
       if (state.hasUnsavedChanges) {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- add a resize handler that repositions active cloze feedback bubbles
- wire the window resize listener to use the new handler

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d661d263088333855c18789c5b8aec