### PR TITLE
Fix cloze shortcut selection handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -1053,7 +1053,14 @@ function bootstrapApp() {
       event.inputType.startsWith("insert");
 
     if (isHashInsertion) {
-      runWithPreservedSelection(() => applyClozeShortcut());
+      rememberEditorSelection();
+      const selectionBeforeShortcut = state.savedSelection
+        ? { ...state.savedSelection }
+        : null;
+      const transformed = runWithPreservedSelection(() => applyClozeShortcut());
+      if (!transformed && selectionBeforeShortcut) {
+        focusEditorPreservingSelection(selectionBeforeShortcut);
+      }
     }
 
     refreshAllClozes();


### PR DESCRIPTION
## Summary
- remember the current selection before running the cloze shortcut so the caret stays in place when no conversion occurs
- restore the previous selection only when the shortcut does not create a cloze to keep the saved selection in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6764f81548333a1defe612cda395e