### PR TITLE
Fix caret position after cloze shortcut

### DIFF
--- a/app.js
+++ b/app.js
@@ -1484,6 +1484,19 @@ function bootstrapApp() {
     range.insertNode(wrapper);
     refreshClozeElement(wrapper);
 
+    const selection = window.getSelection();
+    if (selection && wrapper.parentNode) {
+      try {
+        const afterRange = document.createRange();
+        afterRange.setStartAfter(wrapper);
+        afterRange.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(afterRange);
+      } catch (error) {
+        console.error("Impossible de positionner le curseur après le trou", error);
+      }
+    }
+
     return true;
   }
 


### PR DESCRIPTION
## Summary
- keep the caret positioned after a cloze created from ##text## so typing can continue normally
- log an error if setting the caret fails for debugging purposes

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d677e3be048333b5df18b417548835