### PR TITLE
Fix caret restoration after creating cloze

### DIFF
--- a/app.js
+++ b/app.js
@@ -1135,6 +1135,40 @@ function bootstrapApp() {
 
     range.setStart(startNode, Math.max(0, startOffset));
     range.setEnd(endNode, Math.max(0, endOffset));
+
+    const isCollapsedSelection =
+      typeof saved.start === "number" &&
+      typeof saved.end === "number" &&
+      saved.start === saved.end &&
+      range.collapsed;
+
+    if (isCollapsedSelection) {
+      const referenceNode =
+        range.startContainer && range.startContainer.nodeType === Node.TEXT_NODE
+          ? range.startContainer.parentElement
+          : range.startContainer;
+      const clozeElement =
+        referenceNode && referenceNode.closest
+          ? referenceNode.closest(".cloze")
+          : null;
+
+      if (clozeElement) {
+        const clozeEndRange = document.createRange();
+        clozeEndRange.selectNodeContents(clozeElement);
+        clozeEndRange.collapse(false);
+
+        const atClozeEnd =
+          range.compareBoundaryPoints(Range.START_TO_START, clozeEndRange) === 0 &&
+          range.compareBoundaryPoints(Range.END_TO_END, clozeEndRange) === 0;
+
+        if (atClozeEnd) {
+          range.setStartAfter(clozeElement);
+          range.setEndAfter(clozeElement);
+          range.collapse(true);
+        }
+      }
+    }
+
     selection.removeAllRanges();
     selection.addRange(range);
   }


### PR DESCRIPTION
## Summary
- adjust selection restoration so collapsed carets at the end of a cloze move after the wrapper
- ensure the caret stays collapsed and can be memorized from the updated position

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6798869808333b61ff1caf1bb9d31