### PR TITLE
Add account visibility controls and public directory

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -27,6 +27,28 @@ service cloud.firestore {
       return value is timestamp && value == request.time;
     }
 
+    function isVisibility(value) {
+      return value is string && (value == "public" || value == "private");
+    }
+
+    function userHasValidKeys(data) {
+      return data.keys().hasOnly(['createdAt', 'visibility', 'displayName']);
+    }
+
+    function canCreateUser(data) {
+      return userHasValidKeys(data) &&
+             isServerTimestamp(data.createdAt) &&
+             isVisibility(data.visibility) &&
+             optionalString(data.displayName, 120);
+    }
+
+    function canUpdateUserProfile(newData, existingData) {
+      return userHasValidKeys(newData) &&
+             newData.createdAt == existingData.createdAt &&
+             isVisibility(newData.visibility) &&
+             optionalString(newData.displayName, 120);
+    }
+
     function noteHasValidKeys(data) {
       return data.keys().hasOnly(['title', 'contentHtml', 'createdAt', 'updatedAt']);
     }
@@ -48,11 +70,13 @@ service cloud.firestore {
     }
 
     match /users/{userId} {
-      allow read: if isOwner(userId);
+      allow read: if isOwner(userId) || resource.data.visibility == "public";
 
       allow create: if isOwner(userId) &&
-                    request.resource.data.keys().hasOnly(['createdAt']) &&
-                    isServerTimestamp(request.resource.data.createdAt);
+                    canCreateUser(request.resource.data);
+
+      allow update: if isOwner(userId) &&
+                    canUpdateUserProfile(request.resource.data, resource.data);
 
       allow delete: if isOwner(userId);
 

--- a/index.html
+++ b/index.html
@@ -215,8 +215,40 @@
               autocomplete="nickname"
               placeholder="ex.&nbsp;: astrofan"
             />
+            <fieldset class="visibility-options">
+              <legend>Visibilité du compte</legend>
+              <p class="muted small">
+                Choisissez si votre compte est répertorié publiquement sur cette page.
+              </p>
+              <label class="visibility-choice">
+                <input
+                  type="radio"
+                  name="visibility"
+                  value="private"
+                  checked
+                />
+                <span>
+                  <strong>Compte privé</strong>
+                  <span class="muted small">Seul vous pouvez voir vos fiches.</span>
+                </span>
+              </label>
+              <label class="visibility-choice">
+                <input type="radio" name="visibility" value="public" />
+                <span>
+                  <strong>Compte public</strong>
+                  <span class="muted small">Votre pseudo est listé ci-dessous.</span>
+                </span>
+              </label>
+            </fieldset>
             <button type="submit">Commencer</button>
           </form>
+          <section id="public-accounts" class="public-accounts">
+            <h3>Comptes publics disponibles</h3>
+            <p id="public-users-empty" class="muted small">
+              Aucun compte public pour le moment.
+            </p>
+            <div id="public-users-list" class="public-users-list" role="list"></div>
+          </section>
           <p class="muted small">
             Astuce : vous pouvez revenir plus tard avec le même pseudo pour retrouver vos fiches.
           </p>

--- a/styles.css
+++ b/styles.css
@@ -424,6 +424,90 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   gap: 0.75rem;
 }
 
+.visibility-options {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.visibility-options legend {
+  font-weight: 600;
+  margin-bottom: 0.35rem;
+}
+
+.visibility-options p {
+  margin: 0;
+}
+
+.visibility-choice {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  padding: 0.4rem 0.35rem;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.visibility-choice:hover {
+  background: rgba(26, 115, 232, 0.08);
+}
+
+.visibility-choice input[type="radio"] {
+  margin-top: 0.25rem;
+}
+
+.visibility-choice span {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.public-accounts {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.public-users-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.6rem;
+}
+
+.public-user-button {
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: inherit;
+  border-radius: 0.85rem;
+  padding: 0.65rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  width: 100%;
+  box-shadow: none;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.public-user-button:hover:not(:disabled) {
+  border-color: rgba(26, 115, 232, 0.45);
+  background: rgba(26, 115, 232, 0.08);
+}
+
+.public-user-name {
+  font-weight: 600;
+}
+
+.public-user-pseudo {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;


### PR DESCRIPTION
## Summary
- add account visibility choices to the login form and expose a public accounts list on the welcome screen
- persist user visibility/display names in Firestore and surface a live directory of public users
- update Firestore rules and styles to support the new profile metadata and public directory UI

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6849acaa083338312e69337740ed7