### PR TITLE
Tighten desktop toolbar layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -814,6 +814,35 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   font-variant-numeric: tabular-nums;
 }
 
+@media (min-width: 901px) {
+  .toolbar-group--primary {
+    flex: 0 1 auto;
+  }
+
+  .toolbar-select {
+    flex: 0 1 auto;
+    padding: 0 0.25rem;
+    min-height: 1.6rem;
+    min-width: 100px;
+  }
+
+  .toolbar-group--primary > .toolbar-select,
+  .toolbar-group--primary > .font-size-control {
+    flex: 0 1 auto;
+  }
+
+  .font-size-control {
+    gap: 0.25rem;
+    padding: 0.15rem 0.25rem;
+    min-height: 1.6rem;
+    min-width: 90px;
+  }
+
+  .font-size-control #font-size-value {
+    min-width: 2ch;
+  }
+}
+
 .editor-toolbar .toolbar-button {
   background: #f8f9fa;
   border-radius: 0.5rem;


### PR DESCRIPTION
## Summary
- reduce desktop flex values and minimum widths for primary toolbar groups so controls stay compact on large screens
- shrink desktop padding and min-height on select and font-size controls while keeping mobile rules unchanged
- constrain the font size readout width to avoid stretching adjacent buttons

## Testing
- Manual validation

------
https://chatgpt.com/codex/tasks/task_e_68d688381298833390ce23490e3a7444