### PR TITLE
feat: support hierarchical note tree

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -580,7 +580,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.35rem;
   overflow-y: auto;
   max-height: calc(100vh - 220px);
   padding-right: 0.25rem;
@@ -595,11 +595,47 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-radius: 3px;
 }
 
+.note-node {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .note-row {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 0.5rem;
+  display: flex;
   align-items: stretch;
+  gap: 0.4rem;
+  width: 100%;
+  padding-left: calc(var(--note-depth, 0) * 1.4rem);
+}
+
+.note-toggle,
+.note-toggle-spacer {
+  flex: 0 0 auto;
+  width: 1.75rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.note-toggle {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+  padding: 0;
+  box-shadow: none;
+  color: var(--muted);
+  font-size: 0.9rem;
+  height: 1.9rem;
+}
+
+.note-toggle:hover {
+  background: rgba(26, 115, 232, 0.12);
+  color: var(--accent-strong);
+}
+
+.note-toggle:active {
+  transform: none;
 }
 
 .note-card {
@@ -607,7 +643,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   flex-direction: column;
   align-items: flex-start;
   gap: 0.35rem;
-  width: 100%;
+  flex: 1 1 auto;
   text-align: left;
   background: #ffffff;
   border: 1px solid transparent;
@@ -623,8 +659,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .note-card.active {
   border-color: rgba(26, 115, 232, 0.45);
-  background: rgba(26, 115, 232, 0.1);
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.35);
+  background: rgba(26, 115, 232, 0.12);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.32);
 }
 
 .note-card-title {
@@ -635,6 +671,47 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .note-card-meta {
   font-size: 0.8rem;
   color: var(--muted);
+}
+
+.note-row-actions {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.note-children {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-left: 0.75rem;
+  border-left: 1px dashed rgba(60, 64, 67, 0.2);
+  padding-left: 0.75rem;
+}
+
+.note-children[hidden] {
+  display: none;
+}
+
+.note-add-child {
+  font-size: 1rem;
+  line-height: 1;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+}
+
+.note-toggle-spacer {
+  color: transparent;
+  height: 1.9rem;
+}
+
+.note-row-actions .icon-button {
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .icon-button {


### PR DESCRIPTION
## Summary
- extend note documents with parent and position metadata, building a hierarchical tree after Firestore sync
- render nested notes with expandable rows, child creation controls, and improved active state handling
- cascade delete note hierarchies, maintain sibling ordering, and refresh styles for the new tree layout

## Testing
- Manual UI check via local http server

------
https://chatgpt.com/codex/tasks/task_e_68d68fb34b508333a8c239afe0452bbc