### PR TITLE
Improve Firestore permission guidance

### DIFF
--- a/app.js
+++ b/app.js
@@ -3026,9 +3026,13 @@ function bootstrapApp() {
       (error) => {
         console.error("Erreur lors du chargement des comptes publics", error);
         updatePublicUsersList([]);
+        if (isPermissionDenied(error)) {
+          reportPermissionIssue("Lecture des comptes publics refusée par Firestore");
+        }
         if (ui.publicUsersEmpty) {
-          ui.publicUsersEmpty.textContent =
-            "Impossible de charger les comptes publics pour le moment.";
+          ui.publicUsersEmpty.textContent = isPermissionDenied(error)
+            ? "Activez les règles Firestore fournies dans firestore.rules pour afficher les comptes publics."
+            : "Impossible de charger les comptes publics pour le moment.";
           ui.publicUsersEmpty.classList.remove("hidden");
         }
       }
@@ -3105,6 +3109,11 @@ function bootstrapApp() {
     } catch (error) {
       console.error(error);
       let message = "Impossible de se connecter";
+      if (isPermissionDenied(error)) {
+        reportPermissionIssue("Connexion refusée par Firestore");
+        message =
+          "Permissions Firestore insuffisantes pour se connecter. Consultez la console pour les étapes de configuration.";
+      }
       switch (error?.code) {
         case "auth/invalid-email":
         case "auth/missing-email":


### PR DESCRIPTION
## Summary
- report Firestore permission issues during login with a clear toast message
- surface actionable guidance when loading public accounts fails due to Firestore rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69af8d8f08333a5835368366a9c49