### PR TITLE
Refactor Firestore rule helper variable declarations

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -21,8 +21,8 @@ service cloud.firestore {
     }
 
     function hasMatchingPseudo(userId) {
-      return (let email = normalizedAuthEmail();
-        email != null && email == expectedEmailFor(userId));
+      let email = normalizedAuthEmail();
+      return email != null && email == expectedEmailFor(userId);
     }
 
     function userRecord(userId) {
@@ -30,16 +30,15 @@ service cloud.firestore {
     }
 
     function ownerMatches(userId) {
+      let record = userRecord(userId);
+      let email = normalizedAuthEmail();
       return isSignedIn() &&
-        (let record = userRecord(userId);
-          record.exists() &&
-          (
-            (record.data.ownerUid is string && record.data.ownerUid == request.auth.uid) ||
-            (let email = normalizedAuthEmail();
-              email != null &&
-              record.data.ownerEmail is string &&
-              lower(record.data.ownerEmail) == email)
-          )
+        record.exists() &&
+        (
+          (record.data.ownerUid is string && record.data.ownerUid == request.auth.uid) ||
+          (email != null &&
+            record.data.ownerEmail is string &&
+            lower(record.data.ownerEmail) == email)
         );
     }
 
@@ -48,12 +47,12 @@ service cloud.firestore {
     }
 
     function ensureOwnerFields() {
+      let email = normalizedAuthEmail();
       return request.auth != null &&
         request.auth.uid != null &&
         request.resource.data.ownerUid is string &&
         request.resource.data.ownerUid == request.auth.uid &&
-        (let email = normalizedAuthEmail();
-          email != null &&
+        (email != null &&
           request.resource.data.ownerEmail is string &&
           lower(request.resource.data.ownerEmail) == email);
     }


### PR DESCRIPTION
## Summary
- declare helper variables in Firestore rules before returning expressions
- simplify owner match and owner field validation helpers to share normalized email values

## Testing
- firebase deploy --only firestore:rules *(fails: firebase CLI not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b18cf6a483339dc2790f45076bc7