### PR TITLE
Improve mobile layout for notes

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -734,6 +734,41 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   color: var(--accent-strong);
 }
 
+@media (max-width: 900px) {
+  .note-row {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    padding-left: calc(var(--note-depth, 0) * 1.1rem);
+  }
+
+  .note-card {
+    flex: 1 1 100%;
+  }
+
+  .note-row-actions {
+    width: 100%;
+    justify-content: flex-end;
+    margin-top: 0.25rem;
+  }
+
+  .note-row-actions .icon-button {
+    width: auto;
+    height: auto;
+    min-width: 2.4rem;
+    min-height: 2.4rem;
+  }
+
+  .icon-button {
+    min-width: 2.4rem;
+    min-height: 2.4rem;
+  }
+
+  .note-children {
+    margin-left: 0.5rem;
+    padding-left: 0.55rem;
+  }
+}
+
 .editor-area {
   background: transparent;
   border-radius: 0;


### PR DESCRIPTION
## Summary
- add a mobile-focused media query that wraps note rows and pushes action buttons onto their own line
- increase indentation flexibility and icon button tap targets for smaller screens

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6bd05219083339780b4772395ab4b