### PR TITLE
Add mobile floating new note button

### DIFF
--- a/app.js
+++ b/app.js
@@ -225,6 +225,7 @@ function bootstrapApp() {
     headerMenuBtn: document.getElementById("workspace-menu-btn"),
     headerMenu: document.getElementById("workspace-menu"),
     addNoteBtn: document.getElementById("add-note-btn"),
+    mobileAddNoteBtn: document.getElementById("mobile-add-note-btn"),
     notesContainer: document.getElementById("notes-container"),
     noteTitle: document.getElementById("note-title"),
     noteEditor: document.getElementById("note-editor"),
@@ -246,6 +247,19 @@ function bootstrapApp() {
     revisionModeToggle: document.getElementById("revision-mode-toggle"),
     revisionIterationBtn: document.getElementById("revision-iteration-btn"),
   };
+
+  if (ui.mobileAddNoteBtn && ui.addNoteBtn) {
+    const referenceLabel =
+      ui.addNoteBtn.getAttribute("aria-label")?.trim() ||
+      ui.addNoteBtn.textContent?.trim() ||
+      "";
+
+    if (referenceLabel) {
+      ui.mobileAddNoteBtn.setAttribute("aria-label", referenceLabel);
+    } else {
+      ui.mobileAddNoteBtn.removeAttribute("aria-label");
+    }
+  }
 
   ui.visibilityInputs = ui.loginForm
     ? Array.from(ui.loginForm.querySelectorAll("input[name='visibility']"))
@@ -3328,6 +3342,22 @@ function bootstrapApp() {
         console.error(error);
       });
     });
+    if (ui.mobileAddNoteBtn) {
+      ui.mobileAddNoteBtn.addEventListener("click", () => {
+        try {
+          Promise.resolve(createNote())
+            .catch((error) => {
+              console.error(error);
+            })
+            .finally(() => {
+              setNotesDrawer(false);
+            });
+        } catch (error) {
+          console.error(error);
+          setNotesDrawer(false);
+        }
+      });
+    }
     ui.noteTitle.addEventListener("input", handleTitleInput);
     ui.noteEditor.addEventListener("input", handleEditorInput);
     ui.noteEditor.addEventListener("click", handleEditorClick);

--- a/index.html
+++ b/index.html
@@ -267,11 +267,17 @@
                 <p class="muted small">Tout est enregistré automatiquement.</p>
               </div>
               <div class="note-list-actions">
-                <button id="add-note-btn" type="button">Nouvelle fiche</button>
+                <button id="add-note-btn" type="button" aria-label="Nouvelle fiche">
+                  Nouvelle fiche
+                </button>
               </div>
             </div>
             <div id="notes-container" class="notes-container"></div>
           </aside>
+
+          <button id="mobile-add-note-btn" type="button" aria-label="Nouvelle fiche">
+            Nouvelle fiche
+          </button>
 
           <section class="editor-area">
             <div id="empty-note" class="empty-state">

--- a/styles.css
+++ b/styles.css
@@ -94,6 +94,10 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
+#mobile-add-note-btn {
+  display: none;
+}
+
 button.secondary {
   background: rgba(26, 115, 232, 0.08);
   color: var(--accent-strong);
@@ -735,6 +739,21 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 @media (max-width: 900px) {
+  #mobile-add-note-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: fixed;
+    bottom: calc(1.5rem + env(safe-area-inset-bottom, 0));
+    right: 1.5rem;
+    padding: 0.85rem 1.4rem;
+    border-radius: 999px;
+    font-size: 1rem;
+    box-shadow: 0 12px 28px rgba(26, 115, 232, 0.35);
+    z-index: 80;
+    white-space: nowrap;
+  }
+
   .note-row {
     flex-wrap: wrap;
     align-items: flex-start;


### PR DESCRIPTION
## Summary
- add a floating "Nouvelle fiche" button outside the note list for mobile viewports
- style the new CTA so it appears only below 900px width while keeping the desktop layout unchanged
- wire the button into the existing note creation flow and sync its aria-label with the desktop action

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6be04c840833399fd70f22718d171