### PR TITLE
Make editor toolbar sticky across viewports

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -836,13 +836,19 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  padding: 0;
-  background: transparent;
-  border: none;
-  box-shadow: none;
-  backdrop-filter: none;
-  -webkit-backdrop-filter: none;
+  position: sticky;
+  top: calc(var(--toolbar-offset) + var(--toolbar-sticky-gap));
+  z-index: 60;
+  padding: 0.75rem 0.85rem;
+  margin: 0 auto;
   width: 100%;
+  background: var(--editor-toolbar-surface);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.85rem;
+  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
 .toolbar-row {
@@ -1496,9 +1502,10 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    padding: 0;
+    padding: 0.65rem 0.75rem;
     gap: 0.45rem;
-    box-shadow: none;
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
   }
 
   .toolbar-row {
@@ -1600,6 +1607,10 @@ body.notes-drawer-open .drawer-overlay {
 }
 
 @media (max-width: 560px) {
+  :root {
+    --toolbar-sticky-gap: 0.4rem;
+  }
+
   .app-main {
     padding: 1rem 1rem 1.75rem;
   }
@@ -1625,14 +1636,14 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    padding: 0;
+    padding: 0.55rem 0.6rem;
     gap: 0.35rem;
-    border-radius: 0;
-    align-self: flex-start;
+    border-radius: 0.65rem;
+    align-self: stretch;
     flex-shrink: 0;
-    border: none;
-    box-shadow: none;
-    margin-bottom: 0;
+    border: 1px solid rgba(15, 23, 42, 0.12);
+    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
+    margin: 0;
   }
 
   .editor-toolbar .toolbar-more-toggle {


### PR DESCRIPTION
## Summary
- make the editor toolbar sticky using the dynamic header height offset so the controls stay visible while editing
- adjust responsive spacing at 900px and 560px breakpoints to keep the sticky toolbar aligned on smaller screens

## Testing
- Manual verification in Playwright on desktop and mobile viewports to confirm the toolbar remains visible while scrolling

------
https://chatgpt.com/codex/tasks/task_e_68d6c59ae7608333bb2b8e48a09a5576