### PR TITLE
Refine mobile layout for nested note rows

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,6 +14,9 @@
   --toolbar-offset: var(--header-height);
   --toolbar-sticky-gap: 1rem;
   --editor-toolbar-surface: rgba(255, 255, 255, 0.97);
+  --note-indent-step: 1.4rem;
+  --note-toggle-size: 1.75rem;
+  --note-connector-color: rgba(60, 64, 67, 0.2);
   font-family: "Inter", "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
@@ -610,13 +613,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   align-items: stretch;
   gap: 0.4rem;
   width: 100%;
-  padding-left: calc(var(--note-depth, 0) * 1.4rem);
+  padding-left: calc(var(--note-depth, 0) * var(--note-indent-step));
 }
 
 .note-toggle,
 .note-toggle-spacer {
   flex: 0 0 auto;
-  width: 1.75rem;
+  width: var(--note-toggle-size);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -688,7 +691,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   flex-direction: column;
   gap: 0.25rem;
   margin-left: 0.75rem;
-  border-left: 1px dashed rgba(60, 64, 67, 0.2);
+  border-left: 1px dashed var(--note-connector-color);
   padding-left: 0.75rem;
 }
 
@@ -758,36 +761,76 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   }
 
   .note-row {
-    flex-wrap: wrap;
-    align-items: flex-start;
-    padding-left: calc(var(--note-depth, 0) * 1.1rem);
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--note-toggle-size) minmax(0, 1fr);
+    grid-template-areas:
+      "toggle card"
+      "toggle actions";
+    align-items: start;
+    padding-left: calc(var(--note-depth, 0) * 1rem);
+    gap: 0.5rem 0.55rem;
+  }
+
+  .note-row::before {
+    content: "";
+    position: absolute;
+    top: 0.6rem;
+    left: calc(var(--note-depth, 0) * 1rem + (var(--note-toggle-size) / 2));
+    width: 1px;
+    height: calc(var(--note-toggle-size) + 0.4rem);
+    background: var(--note-connector-color);
+    opacity: 0.55;
+    pointer-events: none;
+  }
+
+  .note-row[style*="--note-depth: 0"]::before,
+  .note-row[style*="--note-depth:0"]::before {
+    content: none;
+  }
+
+  .note-toggle,
+  .note-toggle-spacer {
+    grid-area: toggle;
+    align-self: start;
+    justify-self: start;
+    height: var(--note-toggle-size);
+    grid-row: 1 / span 2;
   }
 
   .note-card {
-    flex: 1 1 100%;
+    grid-area: card;
   }
 
   .note-row-actions {
+    grid-area: actions;
+    display: flex;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    column-gap: 0.45rem;
+    row-gap: 0.35rem;
     width: 100%;
-    justify-content: flex-end;
-    margin-top: 0.25rem;
+    margin-top: 0;
+    padding: 0;
   }
 
   .note-row-actions .icon-button {
     width: auto;
     height: auto;
-    min-width: 2.4rem;
-    min-height: 2.4rem;
+    min-width: 2.6rem;
+    min-height: 2.6rem;
   }
 
   .icon-button {
-    min-width: 2.4rem;
-    min-height: 2.4rem;
+    min-width: 2.6rem;
+    min-height: 2.6rem;
   }
 
   .note-children {
-    margin-left: 0.5rem;
-    padding-left: 0.55rem;
+    margin-left: calc(var(--note-toggle-size) + 0.35rem);
+    padding-left: 0.9rem;
+    border-left-width: 2px;
+    gap: 0.35rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- introduce custom properties to control note indentation, toggle sizing, and connector color
- reorganize the mobile note row layout to stack content and actions while keeping indentation guides visible
- reinforce mobile connector styling and action button touch areas for multi-level note trees

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70ba4cdc48333bc161392339788dd