### PR TITLE
Adjust mobile drawer stacking order

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1449,7 +1449,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   inset: 0;
   background: rgba(30, 42, 50, 0.25);
   backdrop-filter: blur(3px);
-  z-index: 22;
+  z-index: 120;
   transition: opacity 0.2s ease;
   opacity: 0;
   pointer-events: none;
@@ -1516,7 +1516,7 @@ body.notes-drawer-open .drawer-overlay {
     transform: translateX(-110%);
     opacity: 1;
     padding: 1.5rem 1.2rem 2rem;
-    z-index: 25;
+    z-index: 120;
     box-shadow: 0 16px 32px rgba(60, 64, 67, 0.24);
   }
 


### PR DESCRIPTION
## Summary
- raise the drawer overlay z-index so the mobile veil appears above the editor toolbar
- increase the mobile note list z-index to keep the drawer above surrounding UI

## Testing
- Manual check: loaded the site on a mobile viewport and toggled the drawer

------
https://chatgpt.com/codex/tasks/task_e_68d70fab5f8c833396b5234e4bfc9b47