### PR TITLE
Affiner l'espacement de la liste de fiches

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -587,7 +587,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   margin-top: 1.5rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
   overflow-y: auto;
   max-height: calc(100vh - 220px);
   padding-right: 0.25rem;
@@ -605,13 +605,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .note-node {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
 }
 
 .note-row {
   display: flex;
   align-items: stretch;
-  gap: 0.4rem;
+  gap: 0.3rem;
   width: 100%;
   padding-left: calc(var(--note-depth, 0) * var(--note-indent-step));
 }
@@ -649,13 +649,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.35rem;
+  gap: 0.25rem;
   flex: 1 1 auto;
   text-align: left;
   background: #ffffff;
   border: 1px solid transparent;
   border-radius: 0.65rem;
-  padding: 0.8rem 0.95rem;
+  padding: 0.7rem 0.9rem;
   color: inherit;
   box-shadow: none;
 }
@@ -689,7 +689,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .note-children {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
   margin-left: 0.75rem;
   border-left: 1px dashed var(--note-connector-color);
   padding-left: 0.75rem;


### PR DESCRIPTION
## Summary
- reduce vertical spacing gaps in the note list container, nodes, rows and child lists for a more compact layout
- tighten the internal padding and spacing of note cards to keep entries balanced with the new gaps

## Testing
- Manual: Launched the app locally and navigated through notes with parent/child entries expanded to confirm the list remains legible

------
https://chatgpt.com/codex/tasks/task_e_68d7138016f883338a0fc7ab823a8cb3