### PR TITLE
Remove blur effect from drawer overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1447,8 +1447,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .drawer-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(30, 42, 50, 0.25);
-  backdrop-filter: blur(3px);
+  background: rgba(30, 42, 50, 0.35);
   z-index: 120;
   transition: opacity 0.2s ease;
   opacity: 0;


### PR DESCRIPTION
## Summary
- remove the blur filter from the drawer overlay styling
- slightly increase overlay background opacity to maintain modal contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7181081308333bb98b9d0f713f8e0