### PR TITLE
Reorganize header layout for compact controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,42 +32,44 @@
             <h1>Apprentissage actif</h1>
             <p class="subtitle">Des fiches simples, prêtes à apprendre.</p>
           </div>
-        </div>
-        <div class="header-actions">
-          <button
-            type="button"
-            id="revision-mode-toggle"
-            class="header-mode-toggle ghost"
-            aria-pressed="false"
-            aria-label="Activer le mode révision"
-          >
-            Mode révision
-          </button>
-          <button
-            type="button"
-            id="revision-iteration-btn"
-            class="header-iteration-btn"
-            aria-label="Lancer une nouvelle itération"
-          >
-            Nouvelle itération
-          </button>
-          <button
-            type="button"
-            id="workspace-menu-btn"
-            class="header-menu-toggle"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-label="Ouvrir le menu principal"
-          >
-            ⋮
-          </button>
-          <div id="workspace-menu" class="header-menu" role="menu">
-            <p class="menu-meta" role="none">
-              Connecté en tant que <span id="current-user" class="menu-meta-strong"></span>
-            </p>
-            <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
+          <div class="header-top-controls">
+            <button
+              type="button"
+              id="revision-mode-toggle"
+              class="header-mode-toggle ghost"
+              aria-pressed="false"
+              aria-label="Activer le mode révision"
+            >
+              Mode révision
+            </button>
+            <div class="header-menu-wrapper">
+              <button
+                type="button"
+                id="workspace-menu-btn"
+                class="header-menu-toggle"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-label="Ouvrir le menu principal"
+              >
+                ⋮
+              </button>
+              <div id="workspace-menu" class="header-menu" role="menu">
+                <p class="menu-meta" role="none">
+                  Connecté en tant que <span id="current-user" class="menu-meta-strong"></span>
+                </p>
+                <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
+              </div>
+            </div>
           </div>
         </div>
+        <button
+          type="button"
+          id="revision-iteration-btn"
+          class="header-iteration-btn"
+          aria-label="Lancer une nouvelle itération"
+        >
+          Nouvelle itération
+        </button>
       </div>
       <div class="header-toolbar">
         <div class="editor-toolbar" role="toolbar" aria-label="Outils de mise en forme">

--- a/styles.css
+++ b/styles.css
@@ -158,7 +158,6 @@ input[type="text"]:focus {
 .header-top {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
   align-content: center;
@@ -183,6 +182,10 @@ input[type="text"]:focus {
   display: flex;
   align-items: center;
   gap: 0.6rem;
+  flex: 1 1 280px;
+  min-width: 0;
+  flex-wrap: wrap;
+  row-gap: 0.35rem;
 }
 
 .brand-text {
@@ -224,11 +227,17 @@ input[type="text"]:focus {
   color: var(--accent-strong);
 }
 
-.header-actions {
+.header-top-controls {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
+  flex: 0 0 auto;
+}
+
+.header-menu-wrapper {
   position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 #revision-mode-toggle {
@@ -361,7 +370,7 @@ body.header-collapsed .header-toolbar {
 }
 
 body.header-collapsed .brand-text,
-body.header-collapsed .header-actions {
+body.header-collapsed .header-top-controls {
   opacity: 0;
   visibility: hidden;
   pointer-events: none;
@@ -1656,6 +1665,21 @@ body.notes-drawer-open .drawer-overlay {
     --toolbar-sticky-gap: 0.4rem;
   }
 
+  .header-top {
+    gap: 0.5rem;
+  }
+
+  .brand {
+    row-gap: 0.25rem;
+  }
+
+  .header-top-controls {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
   .app-main {
     padding: 1rem 1rem 1.75rem;
   }
@@ -1850,7 +1874,7 @@ body.revision-mode .drawer-overlay {
   display: none !important;
 }
 
-body.revision-mode .header-actions > *:not(#revision-mode-toggle):not(#revision-iteration-btn) {
+body.revision-mode .header-top-controls > *:not(#revision-mode-toggle) {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- regroup revision toggle and workspace menu with the brand title so controls sit next to the app name
- refresh header flex styling to support the new grouping and maintain iteration button placement
- tweak responsive rules below 560px so header controls wrap cleanly on small screens

## Testing
- Manual verification in browser_container (desktop and 480px viewports)

------
https://chatgpt.com/codex/tasks/task_e_68d7191d0dc48333809ee868be5cc096