### PR TITLE
Adjust mobile drawer z-index layering

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1524,7 +1524,7 @@ body.notes-drawer-open .drawer-overlay {
     transform: translateX(-110%);
     opacity: 1;
     padding: 1.5rem 1.2rem 2rem;
-    z-index: 120;
+    z-index: 130;
     box-shadow: 0 16px 32px rgba(60, 64, 67, 0.24);
   }
 


### PR DESCRIPTION
## Summary
- raise the mobile note list drawer z-index so it sits above the overlay
- keep the overlay active to capture outside clicks while allowing drawer controls to remain interactive

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d71cd7fa348333b999b088d9969dc4