### PR TITLE
Aligner l'en-tête mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1670,14 +1670,16 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .brand {
-    row-gap: 0.25rem;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    column-gap: 0.5rem;
   }
 
   .header-top-controls {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-    gap: 0.35rem;
+    justify-content: flex-end;
+    gap: 0.45rem;
+    justify-self: end;
   }
 
   .app-main {


### PR DESCRIPTION
## Summary
- aligne la zone de marque et les contrôles sur une seule ligne sur les écrans ≤560 px
- ajuste les espacements des contrôles pour conserver la lisibilité du menu overflow

## Testing
- Visual check @ 360px viewport

------
https://chatgpt.com/codex/tasks/task_e_68d71dcac768833397452a9decbd1f1f