### PR TITLE
Raise header menu above toolbar overlays

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -313,7 +313,7 @@ input[type="text"]:focus {
   visibility: hidden;
   transform: translateY(-6px);
   transition: opacity 0.2s ease, transform 0.2s ease;
-  z-index: 20;
+  z-index: 200;
 }
 
 .header-menu.open {


### PR DESCRIPTION
## Summary
- increase the header menu z-index so it renders above sticky toolbars and overlays

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d79a56fe688333828086dc786c56f8