### PR TITLE
Refactor auth to email and password flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,58 +205,104 @@
 
     <main class="app-main">
       <section id="login-screen" class="view active">
-        <div class="card">
+        <div class="card auth-card">
           <h2>Bienvenue !</h2>
-          <p>Choisissez un pseudo pour créer vos fiches d'apprentissage actives.</p>
-          <form id="login-form" class="stack">
-            <label for="pseudo">Pseudo</label>
+          <p>Créez un compte ou connectez-vous pour retrouver vos fiches.</p>
+          <nav class="auth-tabs" aria-label="Navigation d'authentification">
+            <button
+              type="button"
+              class="auth-tab active"
+              data-auth-view-target="login"
+              aria-current="page"
+            >
+              Connexion
+            </button>
+            <button
+              type="button"
+              class="auth-tab"
+              data-auth-view-target="register"
+            >
+              Inscription
+            </button>
+            <button
+              type="button"
+              class="auth-tab"
+              data-auth-view-target="reset"
+            >
+              Mot de passe oublié
+            </button>
+          </nav>
+          <form id="login-form" class="stack auth-view" data-auth-view="login">
+            <label for="login-email">E-mail</label>
             <input
-              id="pseudo"
+              id="login-email"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+            <label for="login-password">Mot de passe</label>
+            <input
+              id="login-password"
+              name="password"
+              type="password"
+              autocomplete="current-password"
+              required
+            />
+            <p id="login-error" class="form-message error hidden" role="alert"></p>
+            <button type="submit">Se connecter</button>
+          </form>
+          <form
+            id="register-form"
+            class="stack auth-view hidden"
+            data-auth-view="register"
+            novalidate
+          >
+            <label for="register-email">E-mail</label>
+            <input
+              id="register-email"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+            <label for="register-password">Mot de passe</label>
+            <input
+              id="register-password"
+              name="password"
+              type="password"
+              autocomplete="new-password"
+              required
+              minlength="6"
+            />
+            <label for="register-pseudo">Pseudo (optionnel)</label>
+            <input
+              id="register-pseudo"
               name="pseudo"
               type="text"
-              required
-              minlength="3"
-              maxlength="32"
               autocomplete="nickname"
-              placeholder="ex.&nbsp;: astrofan"
+              maxlength="64"
             />
-            <fieldset class="visibility-options">
-              <legend>Visibilité du compte</legend>
-              <p class="muted small">
-                Choisissez si votre compte est répertorié publiquement sur cette page.
-              </p>
-              <label class="visibility-choice">
-                <input
-                  type="radio"
-                  name="visibility"
-                  value="private"
-                  checked
-                />
-                <span>
-                  <strong>Compte privé</strong>
-                  <span class="muted small">Seul vous pouvez voir vos fiches.</span>
-                </span>
-              </label>
-              <label class="visibility-choice">
-                <input type="radio" name="visibility" value="public" />
-                <span>
-                  <strong>Compte public</strong>
-                  <span class="muted small">Votre pseudo est listé ci-dessous.</span>
-                </span>
-              </label>
-            </fieldset>
-            <button type="submit">Commencer</button>
+            <p id="register-error" class="form-message error hidden" role="alert"></p>
+            <button type="submit">Créer un compte</button>
           </form>
-          <section id="public-accounts" class="public-accounts">
-            <h3>Comptes publics disponibles</h3>
-            <p id="public-users-empty" class="muted small">
-              Aucun compte public pour le moment.
-            </p>
-            <div id="public-users-list" class="public-users-list" role="list"></div>
-          </section>
-          <p class="muted small">
-            Astuce : vous pouvez revenir plus tard avec le même pseudo pour retrouver vos fiches.
-          </p>
+          <form
+            id="reset-form"
+            class="stack auth-view hidden"
+            data-auth-view="reset"
+          >
+            <label for="reset-email">E-mail</label>
+            <input
+              id="reset-email"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+            />
+            <p id="reset-error" class="form-message error hidden" role="alert"></p>
+            <p id="reset-success" class="form-message success hidden" role="status"></p>
+            <button type="submit">Envoyer le lien de réinitialisation</button>
+          </form>
         </div>
       </section>
 

--- a/styles.css
+++ b/styles.css
@@ -440,88 +440,50 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   gap: 0.75rem;
 }
 
-.visibility-options {
-  border: 1px solid var(--border);
-  border-radius: 1rem;
-  padding: 1rem;
+.auth-card {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
-.visibility-options legend {
-  font-weight: 600;
-  margin-bottom: 0.35rem;
-}
-
-.visibility-options p {
-  margin: 0;
-}
-
-.visibility-choice {
+.auth-tabs {
   display: flex;
-  align-items: flex-start;
-  gap: 0.6rem;
-  padding: 0.4rem 0.35rem;
-  border-radius: 0.75rem;
-  cursor: pointer;
-  transition: background 0.2s ease;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin: 1rem 0 0.5rem;
 }
 
-.visibility-choice:hover {
+.auth-tab {
+  flex: 1 1 auto;
   background: rgba(26, 115, 232, 0.08);
-}
-
-.visibility-choice input[type="radio"] {
-  margin-top: 0.25rem;
-}
-
-.visibility-choice span {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-}
-
-.public-accounts {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  margin-top: 0.5rem;
-}
-
-.public-users-list {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
-  gap: 0.6rem;
-}
-
-.public-user-button {
-  border: 1px solid var(--border);
-  background: #ffffff;
-  color: inherit;
-  border-radius: 0.85rem;
-  padding: 0.65rem 0.8rem;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.2rem;
-  width: 100%;
+  color: var(--accent-strong);
+  border: 1px solid rgba(26, 115, 232, 0.18);
   box-shadow: none;
-  transition: border-color 0.2s ease, background 0.2s ease;
 }
 
-.public-user-button:hover:not(:disabled) {
-  border-color: rgba(26, 115, 232, 0.45);
-  background: rgba(26, 115, 232, 0.08);
+.auth-tab.active {
+  background: var(--accent);
+  color: #ffffff;
+  border-color: var(--accent);
 }
 
-.public-user-name {
-  font-weight: 600;
+.auth-view {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
-.public-user-pseudo {
-  font-size: 0.85rem;
-  color: var(--muted);
+.auth-card .form-message {
+  font-size: 0.9rem;
+  line-height: 1.4;
+}
+
+.form-message.error {
+  color: var(--danger);
+}
+
+.form-message.success {
+  color: var(--success);
 }
 
 .sr-only {


### PR DESCRIPTION
## Summary
- replace the pseudo-based entry screen with distinct registration, login, and password reset forms
- rework the authentication flow to use Firebase email/password APIs and persist optional pseudos in profiles/{uid}
- update state management, Firestore access, and UI styling to match the new auth model with inline error feedback

## Testing
- not run (web application)


------
https://chatgpt.com/codex/tasks/task_e_68d7a133a1d48333a55bfa646ae80430