### PR TITLE
Affiche l'heure du dernier enregistrement

### DIFF
--- a/app.js
+++ b/app.js
@@ -223,8 +223,6 @@ function bootstrapApp() {
 
   const relativeTime = new Intl.RelativeTimeFormat("fr", { numeric: "auto" });
   const dateFormatter = new Intl.DateTimeFormat("fr-FR", {
-    day: "2-digit",
-    month: "short",
     hour: "2-digit",
     minute: "2-digit"
   });
@@ -1635,7 +1633,7 @@ function bootstrapApp() {
         ui.saveStatus.textContent = "Enregistrement...";
         break;
       case "saved":
-        ui.saveStatus.textContent = date ? `Enregistré le ${dateFormatter.format(date)}` : "Enregistré";
+        ui.saveStatus.textContent = date ? `Enregistré à ${dateFormatter.format(date)}` : "Enregistré";
         break;
       case "error":
         ui.saveStatus.textContent = "Erreur d'enregistrement";


### PR DESCRIPTION
## Summary
- adapte le formatteur de date pour ne fournir que l'heure et les minutes
- met à jour le message de statut sauvegardé pour afficher « Enregistré à … »

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d7b86768148333b4613df0ede79e10