### PR TITLE
Simplifier l'affichage de la barre latérale des fiches

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,10 +321,6 @@
         <div class="workspace">
           <aside class="note-list" aria-label="Mes fiches">
             <div class="note-list-header">
-              <div class="note-list-title">
-                <h2>Mes fiches</h2>
-                <p class="muted small">Tout est enregistré automatiquement.</p>
-              </div>
               <div class="note-list-actions">
                 <button id="add-note-btn" type="button" aria-label="Nouvelle fiche">
                   Nouvelle fiche

--- a/styles.css
+++ b/styles.css
@@ -538,9 +538,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .note-list-header {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   align-items: flex-start;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .note-list-title h2 {
@@ -555,7 +555,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .notes-container {
-  margin-top: 1.5rem;
+  margin-top: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;


### PR DESCRIPTION
## Summary
- retirer le titre et le message d'aide redondants de la barre latérale des fiches
- aligner le bouton "Nouvelle fiche" sur la gauche et ajuster l'espacement de la liste

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d80b011b308333bc070d391afd0f99