### PR TITLE
Aligner les fiches avec le bouton Nouvelle fiche

### DIFF
--- a/app.js
+++ b/app.js
@@ -2854,6 +2854,7 @@ function bootstrapApp() {
 
     const row = document.createElement("div");
     row.className = "note-row";
+    row.classList.add(hasChildren ? "note-row--has-toggle" : "note-row--no-toggle");
     row.style.setProperty("--note-depth", String(Math.max(level - 1, 0)));
 
     let toggleButton = null;

--- a/styles.css
+++ b/styles.css
@@ -596,6 +596,20 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   justify-content: center;
 }
 
+@media (min-width: 901px) {
+  .note-row--no-toggle .note-toggle-spacer {
+    width: 0;
+  }
+
+  .note-row--no-toggle {
+    gap: 0;
+  }
+
+  .note-row--no-toggle .note-row-actions {
+    margin-left: 0.3rem;
+  }
+}
+
 .note-toggle {
   background: transparent;
   border: 1px solid transparent;


### PR DESCRIPTION
## Summary
- supprime l'espace réservé du bouton de bascule pour aligner les fiches avec le bouton "Nouvelle fiche" sur bureau
- conserve un espacement lisible pour les actions des fiches sans perturber la mise en page mobile

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d80ce0d29483339290214f8c599c98