### PR TITLE
Add toolbar text color picker with palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,12 +116,35 @@
                 class="toolbar-button color-tool"
                 data-action="applyTextColor"
                 data-value="#1f2937"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="text-color-popover"
                 title="Couleur du texte"
               >
                 <span class="icon" aria-hidden="true">A</span>
                 <span class="color-bar" aria-hidden="true"></span>
                 <span class="sr-only">Appliquer la couleur du texte</span>
               </button>
+              <div
+                id="text-color-popover"
+                class="color-popover"
+                role="group"
+                aria-label="Couleurs du texte"
+                aria-hidden="true"
+                hidden
+              >
+                <div class="color-popover__grid" id="text-color-options"></div>
+                <label class="color-popover__custom" for="text-color-custom-input">
+                  <span>Couleur personnalisée</span>
+                  <input
+                    type="color"
+                    id="text-color-custom-input"
+                    name="text-color-custom-input"
+                    value="#1f2937"
+                    aria-label="Choisir une couleur personnalisée"
+                  />
+                </label>
+              </div>
               <button type="button" class="toolbar-button color-tool" data-action="applyHighlight" title="Surligner">
                 <span class="icon" aria-hidden="true">🖍</span>
                 <span class="color-bar highlight" aria-hidden="true"></span>

--- a/styles.css
+++ b/styles.css
@@ -1114,6 +1114,115 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   background: #fde68a;
 }
 
+.toolbar-group--colors {
+  position: relative;
+}
+
+.color-popover {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 40;
+  min-width: 14rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: #ffffff;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.18);
+  display: none;
+  gap: 0.75rem;
+  flex-direction: column;
+}
+
+.color-popover.is-open {
+  display: flex;
+}
+
+.color-popover__grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.45rem;
+}
+
+@media (max-width: 600px) {
+  .color-popover__grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
+.color-swatch {
+  position: relative;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: var(--swatch-color, transparent);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.14);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.color-swatch:hover {
+  transform: translateY(-1px);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.24);
+}
+
+.color-swatch:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.color-swatch.is-selected {
+  box-shadow:
+    inset 0 0 0 2px rgba(255, 255, 255, 0.85),
+    0 0 0 2px rgba(26, 115, 232, 0.35);
+}
+
+.color-popover__custom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.color-popover__custom span {
+  flex: 1;
+}
+
+.color-popover__custom input[type="color"] {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0;
+  border: none;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.65rem;
+  background: transparent;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.12);
+  cursor: pointer;
+}
+
+.color-popover__custom input[type="color"]::-webkit-color-swatch,
+.color-popover__custom input[type="color"]::-webkit-color-swatch-wrapper {
+  border: none;
+  border-radius: 0.55rem;
+  padding: 0;
+}
+
+.color-popover__custom input[type="color"]::-moz-color-swatch {
+  border: none;
+  border-radius: 0.55rem;
+}
+
+.color-popover__custom input[type="color"]:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .editor-toolbar .toolbar-toggle[aria-pressed="true"] {
   background: rgba(26, 115, 232, 0.24);
   border-color: rgba(26, 115, 232, 0.4);


### PR DESCRIPTION
## Summary
- add a text color popover to the toolbar with a palette of presets and a custom color picker
- track the active text color, keep the editor selection intact, and close the popover on outside/escape interactions
- style the new popover grid and controls so the color choice is clearly represented in the toolbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d80f5db99083339211802660b53ff9