### PR TITLE
Déplacer l'action de partage dans le menu contextuel

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,17 +42,6 @@
             >
               Mode révision
             </button>
-            <button
-              type="button"
-              id="share-note-btn"
-              class="header-mode-toggle ghost"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-label="Partager cette fiche"
-              disabled
-            >
-              Partager
-            </button>
             <div class="header-menu-wrapper">
               <button
                 type="button"
@@ -68,6 +57,18 @@
                 <p class="menu-meta" role="none">
                   Connecté en tant que <span id="current-user" class="menu-meta-strong"></span>
                 </p>
+                <button
+                  type="button"
+                  id="share-note-btn"
+                  class="menu-item"
+                  role="menuitem"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                  aria-label="Partager cette fiche"
+                  disabled
+                >
+                  Partager
+                </button>
                 <button id="logout-btn" class="menu-item" role="menuitem">Se déconnecter</button>
               </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -332,6 +332,13 @@ input[type="text"]:focus {
   box-shadow: none;
 }
 
+.header-menu .menu-item:disabled {
+  color: var(--muted);
+  cursor: not-allowed;
+  background: transparent;
+  opacity: 0.6;
+}
+
 .header-menu .menu-meta {
   margin: 0 0 0.3rem;
   padding: 0.45rem 0.75rem 0.55rem;


### PR DESCRIPTION
## Summary
- déplacer le bouton « Partager » de l'en-tête principal vers le menu ⋮ pour libérer de l'espace en affichage mobile
- ajouter un style d'état désactivé cohérent pour les éléments du menu afin de conserver les indications visuelles

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d819a713208333b849a02a4f0ae0a9