### PR TITLE
Harmoniser l'affichage des consignes journalières

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2433,3 +2433,80 @@ body.revision-mode .editor {
 body.revision-mode .editor:focus {
   outline: none;
 }
+
+/*
+ * Mise en forme des consignes d'habitudes. Les consignes quotidiennes
+ * doivent désormais adopter la même mise en page que les consignes de
+ * pratique afin d'offrir une largeur identique pour les sous-consignes.
+ */
+.editor .habit-consigne {
+  width: min(100%, 720px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding: 1.1rem 1.3rem;
+  border-radius: 1.1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  background: linear-gradient(135deg, rgba(254, 226, 226, 0.88), rgba(254, 215, 170, 0.88));
+}
+
+.editor .habit-consigne__title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.editor .habit-consigne__subtitle {
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.editor .habit-consigne__subtasks {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.editor .habit-consigne__subtask {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.9rem;
+  padding: 0.85rem;
+}
+
+.editor .habit-consigne__subtask-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.editor .habit-consigne__subtask-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.editor .habit-consigne__subtask select,
+.editor .habit-consigne__subtask button,
+.editor .habit-consigne__subtask input,
+.editor .habit-consigne__subtask textarea {
+  width: 100%;
+}
+
+.editor .habit-consigne__subtask button {
+  justify-content: center;
+}
+
+.editor .habit-consigne--practice .habit-consigne__subtasks,
+.editor .habit-consigne--daily .habit-consigne__subtasks {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.editor .habit-consigne--daily {
+  background: linear-gradient(135deg, rgba(254, 249, 195, 0.88), rgba(254, 226, 226, 0.88));
+}


### PR DESCRIPTION
## Summary
- aligner la mise en page des blocs `.habit-consigne` pour les modes pratique et journalier
- appliquer la même grille responsive aux sous-consignes afin qu'elles utilisent toute la largeur disponible
- harmoniser les styles internes (titres, actions, champs) pour conserver une expérience cohérente

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82072284c8333b5b5000e77e444fe