### PR TITLE
Fix mobile text color popover visibility on mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -4172,7 +4172,13 @@ function bootstrapApp() {
     const shouldOpen = Boolean(open);
     if (!ui.textColorPopover || !ui.textColorButton) {
       state.isTextColorPopoverOpen = false;
+      if (ui.toolbar) {
+        ui.toolbar.classList.remove("color-popover-open");
+      }
       return;
+    }
+    if (ui.toolbar) {
+      ui.toolbar.classList.toggle("color-popover-open", shouldOpen);
     }
     if (shouldOpen === state.isTextColorPopoverOpen) {
       if (shouldOpen && ui.textColorCustomInput) {

--- a/styles.css
+++ b/styles.css
@@ -2260,6 +2260,10 @@ body.notes-drawer-open .drawer-overlay {
     scrollbar-width: none;
   }
 
+  .editor-toolbar.color-popover-open .toolbar-row {
+    overflow: visible;
+  }
+
   .toolbar-row::-webkit-scrollbar {
     display: none;
   }


### PR DESCRIPTION
## Summary
- toggle a toolbar helper class when opening the text color popover so it can escape horizontal scrolling containers
- allow the toolbar row to overflow visibly on small screens while the text color picker is open so color options appear on mobile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d92efdbab483339de2ccd7aa2853c5