### PR TITLE
Add cloze priority support

### DIFF
--- a/app.js
+++ b/app.js
@@ -171,6 +171,19 @@ function bootstrapApp() {
     "cloze-status-neutral",
     "cloze-status-negative"
   ];
+  const CLOZE_PRIORITY = {
+    HIGH: "high",
+    MEDIUM: "medium",
+    LOW: "low"
+  };
+  const CLOZE_PRIORITY_VALUES = Object.values(CLOZE_PRIORITY);
+  const CLOZE_DEFAULT_PRIORITY = CLOZE_PRIORITY.MEDIUM;
+  const CLOZE_PRIORITY_CLASS_MAP = {
+    [CLOZE_PRIORITY.HIGH]: "cloze-priority-high",
+    [CLOZE_PRIORITY.MEDIUM]: "cloze-priority-medium",
+    [CLOZE_PRIORITY.LOW]: "cloze-priority-low"
+  };
+  const CLOZE_PRIORITY_CLASSES = Object.values(CLOZE_PRIORITY_CLASS_MAP);
   const CLOZE_DEFER_DATA_KEY = "deferMask";
   const CLOZE_MANUAL_REVEAL_SET_KEY = "revealedClozes";
   const CLOZE_MANUAL_REVEAL_DATASET_KEY = "manualReveal";
@@ -3794,6 +3807,20 @@ function bootstrapApp() {
     return normalizeClozePoints(cloze.dataset.points);
   }
 
+  function getClozePriority(cloze) {
+    if (!cloze || !cloze.dataset) {
+      return CLOZE_DEFAULT_PRIORITY;
+    }
+    const rawPriority = cloze.dataset.priority;
+    if (typeof rawPriority === "string") {
+      const normalized = rawPriority.trim().toLowerCase();
+      if (CLOZE_PRIORITY_VALUES.includes(normalized)) {
+        return normalized;
+      }
+    }
+    return CLOZE_DEFAULT_PRIORITY;
+  }
+
   function shouldMaskCloze(cloze, pointsValue = null) {
     if (!cloze) return true;
     if (cloze.dataset[CLOZE_DEFER_DATA_KEY] === "1") {
@@ -3866,6 +3893,15 @@ function bootstrapApp() {
     }
     if (!cloze.dataset.placeholder) {
       cloze.dataset.placeholder = generateClozePlaceholder();
+    }
+    const priority = getClozePriority(cloze);
+    cloze.dataset.priority = priority;
+    CLOZE_PRIORITY_CLASSES.forEach((className) => {
+      cloze.classList.remove(className);
+    });
+    const priorityClassName = CLOZE_PRIORITY_CLASS_MAP[priority];
+    if (priorityClassName) {
+      cloze.classList.add(priorityClassName);
     }
     const points = setClozePoints(cloze, getClozePoints(cloze));
     if (shouldMaskCloze(cloze, points)) {

--- a/styles.css
+++ b/styles.css
@@ -1472,6 +1472,54 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.22);
 }
 
+.editor .cloze.cloze-priority-high,
+.editor .cloze.cloze-priority-medium,
+.editor .cloze.cloze-priority-low {
+  position: relative;
+}
+
+.editor .cloze.cloze-priority-high {
+  border-bottom-style: double;
+}
+
+.editor .cloze.cloze-priority-medium {
+  border-bottom-style: dashed;
+}
+
+.editor .cloze.cloze-priority-low {
+  border-bottom-style: dotted;
+}
+
+.editor .cloze.cloze-priority-high::before,
+.editor .cloze.cloze-priority-medium::before,
+.editor .cloze.cloze-priority-low::before {
+  display: inline-block;
+  font-size: 0.75rem;
+  line-height: 1;
+  margin-right: 0.2rem;
+  color: currentColor;
+  font-weight: 700;
+  content: "";
+}
+
+.editor .cloze.cloze-priority-high::before {
+  content: "🔺";
+}
+
+.editor .cloze.cloze-priority-medium::before {
+  content: "⬡";
+}
+
+.editor .cloze.cloze-priority-low::before {
+  content: "🔻";
+}
+
+.editor .cloze.cloze-masked.cloze-priority-high::before,
+.editor .cloze.cloze-masked.cloze-priority-medium::before,
+.editor .cloze.cloze-masked.cloze-priority-low::before {
+  color: var(--accent-strong);
+}
+
 .editor .cloze:not(.cloze-masked) {
   cursor: text;
   color: var(--fg);


### PR DESCRIPTION
## Summary
- define constants and helper utilities to normalize cloze priority metadata
- ensure cloze refresh assigns default priorities and priority-specific CSS classes
- add masked and revealed styling cues for each cloze priority level

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbafb8edb48333aee55f56595a4210