### PR TITLE
Add cloze priority filter menu to revision toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,14 +74,59 @@
             </div>
           </div>
         </div>
-        <button
-          type="button"
-          id="revision-iteration-btn"
-          class="header-iteration-btn"
-          aria-label="Lancer une nouvelle itération"
-        >
-          Nouvelle itération
-        </button>
+        <div class="header-iteration-controls">
+          <button
+            type="button"
+            id="revision-iteration-btn"
+            class="header-iteration-btn"
+            aria-label="Lancer une nouvelle itération"
+          >
+            Nouvelle itération
+          </button>
+          <div class="header-filter" data-filter="cloze-priority">
+            <button
+              type="button"
+              id="cloze-filter-btn"
+              class="header-icon-button header-filter-btn"
+              aria-haspopup="true"
+              aria-expanded="false"
+              aria-controls="cloze-filter-menu"
+              aria-pressed="false"
+            >
+              <span aria-hidden="true">👁</span>
+              <span class="sr-only">Filtrer les textes à trous par priorité</span>
+            </button>
+            <div
+              id="cloze-filter-menu"
+              class="header-filter-menu"
+              role="group"
+              aria-labelledby="cloze-filter-btn"
+              aria-hidden="true"
+              hidden
+              tabindex="-1"
+            >
+              <fieldset class="header-filter-fieldset">
+                <legend class="sr-only">Priorités des textes à trous à afficher</legend>
+                <label class="header-filter-option">
+                  <input type="checkbox" data-priority="all" checked />
+                  <span>Tout afficher</span>
+                </label>
+                <label class="header-filter-option">
+                  <input type="checkbox" data-priority="high" checked />
+                  <span>Priorité haute</span>
+                </label>
+                <label class="header-filter-option">
+                  <input type="checkbox" data-priority="medium" checked />
+                  <span>Priorité moyenne</span>
+                </label>
+                <label class="header-filter-option">
+                  <input type="checkbox" data-priority="low" checked />
+                  <span>Priorité basse</span>
+                </label>
+              </fieldset>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="header-toolbar">
         <div class="editor-toolbar" role="toolbar" aria-label="Outils de mise en forme">

--- a/styles.css
+++ b/styles.css
@@ -234,6 +234,106 @@ input[type="text"]:focus {
   flex: 0 0 auto;
 }
 
+.header-iteration-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-left: auto;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.header-filter {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.header-filter-btn {
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 999px;
+  font-size: 1.15rem;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.header-filter-btn.is-active,
+.header-filter-btn:focus-visible {
+  background: rgba(26, 115, 232, 0.18);
+  color: var(--accent-strong);
+}
+
+.header-filter-menu {
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 0;
+  min-width: 15rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #ffffff;
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.18);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  transform-origin: top right;
+  opacity: 0;
+  transform: scale(0.97) translateY(-0.2rem);
+  pointer-events: none;
+  z-index: 120;
+}
+
+.header-filter-menu.is-open {
+  opacity: 1;
+  transform: scale(1) translateY(0);
+  pointer-events: auto;
+}
+
+.header-filter-menu[hidden] {
+  display: none;
+}
+
+.header-filter-menu:focus {
+  outline: none;
+}
+
+.header-filter-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+
+.header-filter-option {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.92rem;
+  color: var(--fg);
+  line-height: 1.2;
+}
+
+.header-filter-option input[type="checkbox"] {
+  width: 1.05rem;
+  height: 1.05rem;
+  accent-color: var(--accent);
+}
+
+@media (max-width: 720px) {
+  .header-iteration-controls {
+    width: 100%;
+    justify-content: flex-start;
+    margin-left: 0;
+  }
+
+  .header-filter-menu {
+    left: 0;
+    right: auto;
+    transform-origin: top left;
+  }
+}
+
 .header-menu-wrapper {
   position: relative;
   display: inline-flex;
@@ -1632,6 +1732,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
     box-shadow 0.2s ease;
   box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.22);
+}
+
+.editor .cloze.cloze-priority-hidden {
+  display: none;
 }
 
 .editor .cloze.cloze-priority-high,


### PR DESCRIPTION
## Summary
- add an eye icon filter button with an accessible checklist for cloze priorities next to the revision iteration action
- style the new filter control, its popover, and the hidden cloze class with responsive behavior and active states
- track filter state in the app logic, wire menu interactions, and hide filtered clozes during revision without triggering feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbbe0ade408333a0f5e21f3e8db863