### PR TITLE
Ensure priority filtered clozes stay masked without hiding placeholders

### DIFF
--- a/app.js
+++ b/app.js
@@ -187,6 +187,7 @@ function bootstrapApp() {
   const CLOZE_DEFER_DATA_KEY = "deferMask";
   const CLOZE_MANUAL_REVEAL_SET_KEY = "revealedClozes";
   const CLOZE_MANUAL_REVEAL_DATASET_KEY = "manualReveal";
+  const CLOZE_PRIORITY_FILTER_DATASET_KEY = "priorityHidden";
   const CLOZE_MANUAL_REVEAL_ATTR = "data-manual-reveal";
 
   const SHARE_ROLE_VIEWER = "viewer";
@@ -3995,6 +3996,9 @@ function bootstrapApp() {
     if (cloze.dataset[CLOZE_DEFER_DATA_KEY] === "1") {
       return false;
     }
+    if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] === "1") {
+      return true;
+    }
     if (cloze.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY] === "1") {
       return false;
     }
@@ -4226,7 +4230,19 @@ function bootstrapApp() {
     clozes.forEach((cloze) => {
       const priority = normalizeClozePriorityValue(getClozePriority(cloze));
       const isVisible = !shouldFilter || priorities.has(priority);
-      cloze.classList.toggle("cloze-priority-hidden", !isVisible);
+      const isPriorityHidden = !isVisible;
+      cloze.classList.toggle("cloze-priority-hidden", isPriorityHidden);
+      if (shouldFilter) {
+        if (isPriorityHidden) {
+          cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] = "1";
+        } else {
+          delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+        }
+        refreshClozeElement(cloze);
+      } else if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY]) {
+        delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+        refreshClozeElement(cloze);
+      }
     });
     if (state.activeCloze && state.activeCloze.classList.contains("cloze-priority-hidden")) {
       hideClozeFeedback();

--- a/styles.css
+++ b/styles.css
@@ -1735,7 +1735,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor .cloze.cloze-priority-hidden {
-  display: none;
+  pointer-events: none;
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .editor .cloze.cloze-priority-high,


### PR DESCRIPTION
## Summary
- add a dedicated dataset flag so priority-filtered clozes are masked ahead of manual reveals
- refresh cloze masking when the priority filter toggles during revision mode
- keep priority-hidden clozes visible with disabled styling instead of removing them from layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcdf4b7748333845cbffc509655e6