### PR TITLE
Harmonise les contours des cloze dans l’éditeur

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1719,19 +1719,17 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor .cloze {
-  background: rgba(26, 115, 232, 0.15);
-  color: var(--accent-strong);
-  padding: 0.12rem 0.45rem;
-  border-radius: 0.45rem;
+  background: #ffffff;
+  color: var(--fg);
+  padding: 0.12rem 0.6rem;
+  border-radius: 999px;
   font-weight: 600;
-  border-bottom: 2px solid rgba(26, 115, 232, 0.35);
+  border: 2px solid #000000;
   cursor: pointer;
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
-    box-shadow 0.2s ease;
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.22);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
 .editor .cloze.cloze-priority-hidden {
@@ -1740,90 +1738,55 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   opacity: 0.45;
 }
 
-.editor .cloze.cloze-priority-high,
-.editor .cloze.cloze-priority-medium,
-.editor .cloze.cloze-priority-low {
-  position: relative;
-}
-
 .editor .cloze.cloze-priority-high {
-  border-bottom-style: double;
+  background: #e6e6e6;
+  border-style: solid;
+  border-color: #000000;
 }
 
 .editor .cloze.cloze-priority-medium {
-  border-bottom-style: dashed;
+  background: #ffffff;
+  border-style: solid;
+  border-color: #000000;
 }
 
 .editor .cloze.cloze-priority-low {
-  border-bottom-style: dotted;
-}
-
-.editor .cloze.cloze-priority-high::before,
-.editor .cloze.cloze-priority-medium::before,
-.editor .cloze.cloze-priority-low::before {
-  display: inline-block;
-  font-size: 0.75rem;
-  line-height: 1;
-  margin-right: 0.2rem;
-  color: currentColor;
-  font-weight: 700;
-  content: "";
-}
-
-.editor .cloze.cloze-priority-high::before {
-  content: "🔺";
-}
-
-.editor .cloze.cloze-priority-medium::before {
-  content: "⬡";
-}
-
-.editor .cloze.cloze-priority-low::before {
-  content: "🔻";
-}
-
-.editor .cloze.cloze-masked.cloze-priority-high::before,
-.editor .cloze.cloze-masked.cloze-priority-medium::before,
-.editor .cloze.cloze-masked.cloze-priority-low::before {
-  color: var(--accent-strong);
+  background: #ffffff;
+  border-style: dotted;
+  border-color: #000000;
 }
 
 .editor .cloze:not(.cloze-masked) {
   cursor: text;
   color: var(--fg);
-  background: rgba(26, 115, 232, 0.12);
-  border-bottom-color: rgba(26, 115, 232, 0.35);
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.28);
+  background: #ffffff;
+  border-color: #000000;
 }
 
 .editor .cloze:not(.cloze-masked).cloze-status-positive {
   background: rgba(24, 128, 56, 0.18);
-  border-bottom-color: rgba(24, 128, 56, 0.48);
-  box-shadow: inset 0 0 0 1px rgba(24, 128, 56, 0.45);
+  border-color: rgba(24, 128, 56, 0.65);
 }
 
 .editor .cloze:not(.cloze-masked).cloze-status-neutral {
   background: rgba(249, 171, 0, 0.22);
-  border-bottom-color: rgba(249, 171, 0, 0.5);
-  box-shadow: inset 0 0 0 1px rgba(249, 171, 0, 0.55);
+  border-color: rgba(249, 171, 0, 0.65);
 }
 
 .editor .cloze:not(.cloze-masked).cloze-status-negative {
   background: rgba(217, 48, 37, 0.2);
-  border-bottom-color: rgba(217, 48, 37, 0.55);
-  box-shadow: inset 0 0 0 1px rgba(217, 48, 37, 0.55);
+  border-color: rgba(217, 48, 37, 0.65);
 }
 
 .editor .cloze:hover {
-  background: rgba(26, 115, 232, 0.25);
+  background: rgba(26, 115, 232, 0.18);
 }
 
 .editor .cloze.cloze-masked {
   color: transparent;
   position: relative;
   background: rgba(95, 99, 104, 0.16);
-  border-bottom-color: rgba(95, 99, 104, 0.45);
-  box-shadow: none;
+  border-color: rgba(95, 99, 104, 0.45);
 }
 
 .editor .cloze.cloze-masked::after {
@@ -1837,13 +1800,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .editor .cloze.cloze-masked:hover {
   background: rgba(26, 115, 232, 0.18);
-  border-bottom-color: rgba(26, 115, 232, 0.45);
+  border-color: rgba(26, 115, 232, 0.45);
 }
 
 .editor .cloze.cloze-masked.cloze-revealed {
   color: var(--fg);
   background: #e8f0fe;
-  border-bottom-color: rgba(26, 115, 232, 0.45);
+  border-color: rgba(26, 115, 232, 0.45);
 }
 
 .editor .cloze.cloze-masked.cloze-revealed::after {


### PR DESCRIPTION
## Summary
- remanie le style de base des cloze avec un fond blanc et un contour elliptique noir
- ajuste les variantes de priorité pour refléter les nouveaux contours et supprime les icônes
- aligne les états masqués et de statut sur le nouveau système de bordures

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dbcf752af08333bf9025f35bc749a2