### PR TITLE
Adjust masked cloze backgrounds by priority

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1785,8 +1785,21 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .editor .cloze.cloze-masked {
   color: transparent;
   position: relative;
+}
+
+.editor .cloze.cloze-masked.cloze-priority-high {
   background: rgba(95, 99, 104, 0.16);
   border-color: rgba(95, 99, 104, 0.45);
+}
+
+.editor .cloze.cloze-masked.cloze-priority-medium {
+  background: #ffffff;
+  border-color: rgba(95, 99, 104, 0.45);
+}
+
+.editor .cloze.cloze-masked.cloze-priority-low {
+  background: #ffffff;
+  border-color: rgba(95, 99, 104, 0.35);
 }
 
 .editor .cloze.cloze-masked::after {


### PR DESCRIPTION
## Summary
- limit the grey masked background to high-priority clozes
- keep masked medium and low priority clozes on white while preserving masking indicators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbd5b70f748333bb5513f8b80b7da8