### PR TITLE
Allow feedback popup on priority-revealed clozes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4956,10 +4956,18 @@ function bootstrapApp() {
 
     const wasMasked = cloze.classList.contains("cloze-masked");
     const manualRevealSet = getManualRevealSet();
+    const hasPriorityManualReveal =
+      cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] === "1";
+    const hasDeferredReveal =
+      cloze.dataset[CLOZE_DEFER_DATA_KEY] === "1" ||
+      cloze.dataset.defer === "1";
+
     if (wasMasked) {
       manualRevealSet.add(cloze);
       cloze.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY] = "1";
       refreshClozeElement(cloze);
+    } else if (hasPriorityManualReveal || hasDeferredReveal) {
+      manualRevealSet.add(cloze);
     }
 
     const isManuallyRevealed = manualRevealSet.has(cloze);


### PR DESCRIPTION
## Summary
- ensure clozes auto-revealed by priority or deferred status are tracked as manually revealed so the feedback popup can open

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbd9c232d4833382ef4e691e82007a