### PR TITLE
Handle non-element targets in closestElement utility

### DIFF
--- a/app.js
+++ b/app.js
@@ -649,10 +649,17 @@ function bootstrapApp() {
   }
 
   function closestElement(target, selector) {
-    if (!target || typeof target.closest !== "function") {
+    let element = target;
+
+    while (element && typeof element.closest !== "function") {
+      element = element.parentElement;
+    }
+
+    if (!element) {
       return null;
     }
-    return target.closest(selector);
+
+    return element.closest(selector);
   }
 
   function setNotesButtonLabel(label) {


### PR DESCRIPTION
## Summary
- update the shared closestElement helper to climb up to the nearest element before delegating to Element.closest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbe01a15bc8333b50d52ca7d14efbf