### PR TITLE
Allow manual reveal of filtered clozes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4242,12 +4242,18 @@ function bootstrapApp() {
       const priority = normalizeClozePriorityValue(getClozePriority(cloze));
       const isVisible = !shouldFilter || priorities.has(priority);
       const isPriorityHidden = !isVisible;
+      const hasPriorityManualReveal =
+        cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] === "1";
       cloze.classList.toggle("cloze-priority-hidden", isPriorityHidden);
       if (shouldFilter) {
         if (isPriorityHidden) {
-          cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] = "1";
-          if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
-            delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
+          if (hasPriorityManualReveal) {
+            delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+          } else {
+            cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] = "1";
+            if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
+              delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
+            }
           }
         } else {
           delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
@@ -4956,13 +4962,23 @@ function bootstrapApp() {
 
   function handleEditorClick(event) {
     const cloze = closestElement(event.target, ".cloze");
-    if (!cloze || cloze.classList.contains("cloze-priority-hidden")) {
+    if (!cloze) {
       hideClozeFeedback();
       return;
     }
 
-    const wasMasked = cloze.classList.contains("cloze-masked");
     const manualRevealSet = getManualRevealSet();
+    const wasPriorityHidden = cloze.classList.contains("cloze-priority-hidden");
+    const wasMasked = cloze.classList.contains("cloze-masked");
+    if (wasPriorityHidden) {
+      manualRevealSet.add(cloze);
+      cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
+      if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] === "1") {
+        delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+      }
+      refreshClozeElement(cloze);
+    }
+
     const hasPriorityManualReveal =
       cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] === "1";
     const hasDeferredReveal =

--- a/styles.css
+++ b/styles.css
@@ -1733,8 +1733,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor .cloze.cloze-priority-hidden {
-  pointer-events: none;
-  cursor: not-allowed;
+  pointer-events: auto;
+  cursor: pointer;
   opacity: 0.45;
 }
 
@@ -1756,7 +1756,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-color: #000000;
 }
 
-.editor .cloze:not(.cloze-masked) {
+.editor .cloze:not(.cloze-masked):not(.cloze-priority-hidden) {
   cursor: text;
   color: var(--fg);
   background: #ffffff;


### PR DESCRIPTION
## Summary
- allow clicking on priority-filtered clozes to flag them as manually revealed and open the evaluation popover
- keep priority-filtered clozes visually distinct while skipping automatic re-hiding once manually revealed
- restore pointer interactions for filtered clozes while preserving the visual cue in revision mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbe6f2d2dc8333a61c8756dc0b438e