### PR TITLE
Stop auto-marking clozes as manually revealed

### DIFF
--- a/app.js
+++ b/app.js
@@ -4257,7 +4257,6 @@ function bootstrapApp() {
           }
         } else {
           delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
-          cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
         }
         refreshClozeElement(cloze);
       } else {


### PR DESCRIPTION
## Summary
- remove the automatic priorityManualReveal dataset assignment when cloze priorities are visible
- keep the manual reveal flag exclusively for clozes revealed by user interaction so the filter can hide them again

## Testing
- not run (UI flow requires manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68dbea99411883338c76a5f4ab94936b