### PR TITLE
Fix priority filter to remask manually revealed clozes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4242,19 +4242,17 @@ function bootstrapApp() {
       const priority = normalizeClozePriorityValue(getClozePriority(cloze));
       const isVisible = !shouldFilter || priorities.has(priority);
       const isPriorityHidden = !isVisible;
-      const hasPriorityManualReveal =
-        cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] === "1";
       cloze.classList.toggle("cloze-priority-hidden", isPriorityHidden);
       if (shouldFilter) {
         if (isPriorityHidden) {
-          if (hasPriorityManualReveal) {
-            delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
-          } else {
-            cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] = "1";
-            if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
-              delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
-            }
+          cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY] = "1";
+          if (cloze.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY]) {
+            delete cloze.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY];
           }
+          if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
+            delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
+          }
+          getManualRevealSet().delete(cloze);
         } else {
           delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
         }


### PR DESCRIPTION
## Summary
- ensure clozes hidden by the priority filter keep the hidden flag and drop manual reveal markers
- clear the priority manual reveal dataset entry and remove the cloze from the manual reveal cache

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68dbfc170da08333b05ff26d0ef4822d