### PR TITLE
Ensure priority filter reveals clozes

### DIFF
--- a/app.js
+++ b/app.js
@@ -4254,7 +4254,11 @@ function bootstrapApp() {
           }
           getManualRevealSet().delete(cloze);
         } else {
-          delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+          if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY]) {
+            delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
+          }
+          cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
+          getManualRevealSet().add(cloze);
         }
         refreshClozeElement(cloze);
       } else {


### PR DESCRIPTION
## Summary
- set a priority manual reveal marker and WeakSet entry when a filtered cloze is visible in revision mode
- retain the existing cleanup for manual reveal markers when priorities are hidden

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc008df200833396192e5688255965