### PR TITLE
Refine cloze filter override handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -4246,14 +4246,8 @@ function bootstrapApp() {
         cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] === "1";
       const hasDeferredReveal = cloze.dataset[CLOZE_DEFER_DATA_KEY] === "1";
       const hasPositivePoints = getClozePoints(cloze) > 0;
-      const isInManualRevealSet = manualRevealSet.has(cloze);
-      const hasManualOverride =
-        hasManualRevealAttr ||
-        hasPriorityManualReveal ||
-        hasDeferredReveal ||
-        hasPositivePoints ||
-        isInManualRevealSet;
-      const shouldHideForPriority = !isVisible && !hasManualOverride;
+      const hasSpacedRepetitionOverride = hasDeferredReveal || hasPositivePoints;
+      const shouldHideForPriority = !isVisible && !hasSpacedRepetitionOverride;
 
       if (shouldHideForPriority) {
         cloze.classList.add("cloze-priority-hidden");
@@ -4270,11 +4264,20 @@ function bootstrapApp() {
         if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY]) {
           delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
         }
-        if (hasManualOverride) {
+        const hasSessionRevealMarker =
+          hasManualRevealAttr || hasPriorityManualReveal;
+        const shouldTrackManualReveal = isVisible || hasSessionRevealMarker;
+
+        if (shouldTrackManualReveal) {
           manualRevealSet.add(cloze);
+          if (isVisible && !hasSessionRevealMarker) {
+            cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
+          }
         } else {
-          cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
-          manualRevealSet.add(cloze);
+          manualRevealSet.delete(cloze);
+          if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
+            delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
+          }
         }
       }
       refreshClozeElement(cloze);


### PR DESCRIPTION
## Summary
- restrict priority filter overrides to deferred masks or positive spaced-repetition points
- keep clearing transient reveal markers when a cloze is hidden by the priority filter
- only persist manual reveal tracking when the filter explicitly shows the cloze or an existing session-wide reveal is in place

## Testing
- not run (UI verification requires Firebase content and authentication)

------
https://chatgpt.com/codex/tasks/task_e_68dc0d6bb49c833392f978ba58ff1015