### PR TITLE
Ensure cloze filter reveal persists

### DIFF
--- a/app.js
+++ b/app.js
@@ -4267,7 +4267,10 @@ function bootstrapApp() {
         if (cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY]) {
           delete cloze.dataset[CLOZE_PRIORITY_FILTER_DATASET_KEY];
         }
-        if (hasManualOverride) {
+        if (isVisible) {
+          cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
+          manualRevealSet.add(cloze);
+        } else if (hasManualOverride) {
           manualRevealSet.add(cloze);
         }
       }


### PR DESCRIPTION
## Summary
- ensure clozes exposed by the priority filter are marked as manually revealed
- preserve existing priority-hide logic so toggling back to hidden re-masks the cloze

## Testing
- not run (not run: manual verification required)

------
https://chatgpt.com/codex/tasks/task_e_68dc144a8fdc8333921ba40f55d8b105