### PR TITLE
Fix cloze priority filter manual reveal handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -4364,9 +4364,18 @@ function bootstrapApp() {
       const hasPositiveScore = getClozeScore(cloze) > 0;
       const hasSpacedRepetitionOverride = hasDeferredReveal || hasPositiveScore;
       const hasManualOverride =
-        hasManualRevealAttr || hasPriorityManualReveal || manualRevealSet.has(cloze);
-      const shouldHideForPriority =
-        !isVisible && !hasSpacedRepetitionOverride && !hasManualOverride;
+        isVisible &&
+        (hasManualRevealAttr ||
+          hasPriorityManualReveal ||
+          manualRevealSet.has(cloze));
+      const shouldHideForPriority = !isVisible && !hasSpacedRepetitionOverride;
+
+      if (!isVisible) {
+        if (cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY]) {
+          delete cloze.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY];
+        }
+        manualRevealSet.delete(cloze);
+      }
 
       if (shouldHideForPriority) {
         cloze.classList.add("cloze-priority-hidden");


### PR DESCRIPTION
## Summary
- restrict manual reveal tracking to priorities that remain selected and update the hide condition accordingly
- clear priority manual reveal markers whenever a priority is deselected, even if spaced repetition keeps the cloze visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc299752cc8333b87508359e539b39