### PR TITLE
Ajuste le masquage des clozes selon le délai de révision

### DIFF
--- a/app.js
+++ b/app.js
@@ -4134,9 +4134,13 @@ function bootstrapApp() {
     if (state[CLOZE_MANUAL_REVEAL_SET_KEY] && state[CLOZE_MANUAL_REVEAL_SET_KEY].has(cloze)) {
       return false;
     }
-    const score =
-      scoreValue === null ? getClozeScore(cloze) : clampClozeScore(scoreValue);
-    return score <= 0;
+    let delay = getClozeRevisionDelay(cloze);
+    if (delay === null) {
+      const score =
+        scoreValue === null ? getClozeScore(cloze) : clampClozeScore(scoreValue);
+      delay = computeRevisionDelay(score);
+    }
+    return delay === null || delay <= 0;
   }
 
   function updateClozeMaskState(cloze, shouldMask) {


### PR DESCRIPTION
## Summary
- utilise le délai de révision pour décider du masquage des clozes
- recalcule un délai de repli à partir du score si aucun délai n’est stocké

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc3162ee7c833396770f31b97209c2