### PR TITLE
Fix cloze visibility defaults and improve list editing

### DIFF
--- a/app.js
+++ b/app.js
@@ -361,6 +361,11 @@ function bootstrapApp() {
     if (!(state.visibleClozePriorities instanceof Set)) {
       state.visibleClozePriorities = new Set();
     }
+    if (state.visibleClozePriorities.size === 0) {
+      CLOZE_PRIORITY_VALUES.forEach((value) => {
+        state.visibleClozePriorities.add(value);
+      });
+    }
     return state.visibleClozePriorities;
   }
 
@@ -4885,6 +4890,9 @@ function bootstrapApp() {
     setClozeRevisionDelay(wrapper, 0);
     wrapper.dataset.priority = normalizeClozePriorityValue(priority);
     wrapper.classList.add("cloze-masked");
+    wrapper.dataset[CLOZE_MANUAL_REVEAL_DATASET_KEY] = "1";
+    wrapper.dataset[CLOZE_PRIORITY_MANUAL_REVEAL_DATASET_KEY] = "1";
+    getManualRevealSet().add(wrapper);
 
     const fragment = range.extractContents();
     wrapper.appendChild(fragment);

--- a/styles.css
+++ b/styles.css
@@ -1726,9 +1726,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   font-weight: 600;
   border: 2px solid #000000;
   cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
+  display: inline;
+  white-space: normal;
   transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
 }
 
@@ -1785,6 +1784,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .editor .cloze.cloze-masked {
   color: transparent;
   position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .editor .cloze.cloze-masked.cloze-priority-high {


### PR DESCRIPTION
## Summary
- ensure cloze visibility filters default to showing every priority so new blanks stay editable
- reveal newly created clozes immediately and adjust their styling so editing inside lists behaves predictably

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfc2340fc883338cf99a5f19761f3f