### PR TITLE
Adjust cloze masked layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1744,9 +1744,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .editor .cloze--block.cloze-masked:not(ul):not(ol):not(li):not(table) {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
+  position: relative;
 }
 
 .editor .cloze--block.cloze-masked::after {
@@ -1837,9 +1835,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .editor .cloze.cloze-masked {
   color: transparent;
   position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
+  display: inline-block;
+  vertical-align: baseline;
 }
 
 .editor .cloze.cloze-masked.cloze-priority-high {
@@ -1864,6 +1861,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   font-weight: 600;
   font-size: 0.72rem;
   text-transform: uppercase;
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: inherit;
+  pointer-events: none;
 }
 
 .editor .cloze.cloze-masked:hover {


### PR DESCRIPTION
## Summary
- replace the flex-based layout for masked cloze elements with an inline-block approach to keep them editable
- overlay the placeholder text with an absolutely positioned pseudo-element to preserve alignment
- ensure block-level masked cloze containers remain relative for correct placeholder positioning

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0f0dc78b08333a2db3a53bc22f339