### PR TITLE
Densify note list UI spacing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -14,8 +14,8 @@
   --toolbar-offset: var(--header-height);
   --toolbar-sticky-gap: 1rem;
   --editor-toolbar-surface: rgba(255, 255, 255, 0.97);
-  --note-indent-step: 1.4rem;
-  --note-toggle-size: 1.75rem;
+  --note-indent-step: 1.05rem;
+  --note-toggle-size: 1.4rem;
   --note-connector-color: rgba(60, 64, 67, 0.2);
   font-family: "Inter", "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
@@ -630,7 +630,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-radius: 0.85rem;
   border: 1px solid var(--border);
   box-shadow: 0 1px 3px rgba(60, 64, 67, 0.12);
-  padding: 1.25rem;
+  padding: 0.95rem 1rem;
   display: flex;
   flex-direction: column;
   min-height: 540px;
@@ -662,10 +662,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .notes-container {
-  margin-top: 1rem;
+  margin-top: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.18rem;
   overflow-y: auto;
   max-height: calc(100vh - 220px);
   padding-right: 0.25rem;
@@ -689,7 +689,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .note-row {
   display: flex;
   align-items: stretch;
-  gap: 0.3rem;
+  gap: 0.25rem;
   width: 100%;
   padding-left: calc(var(--note-depth, 0) * var(--note-indent-step));
 }
@@ -725,7 +725,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   box-shadow: none;
   color: var(--muted);
   font-size: 0.9rem;
-  height: 1.9rem;
+  height: calc(var(--note-toggle-size) + 0.25rem);
 }
 
 .note-toggle:hover {
@@ -739,52 +739,61 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .note-card {
   display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.25rem;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
   flex: 1 1 auto;
   text-align: left;
-  background: #ffffff;
+  background: transparent;
   border: 1px solid transparent;
-  border-radius: 0.65rem;
-  padding: 0.7rem 0.9rem;
+  border-left: 3px solid rgba(60, 64, 67, 0.16);
+  border-radius: 0.5rem;
+  padding: 0.45rem 0.65rem;
   color: inherit;
   box-shadow: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
 
 .note-card:hover {
-  background: #f1f3f4;
+  background: rgba(60, 64, 67, 0.08);
+  border-left-color: rgba(26, 115, 232, 0.35);
 }
 
 .note-card.active {
-  border-color: rgba(26, 115, 232, 0.45);
+  border-color: rgba(26, 115, 232, 0.35);
+  border-left-color: var(--accent);
   background: rgba(26, 115, 232, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2);
 }
 
 .note-card-title {
   font-weight: 600;
   font-size: 0.98rem;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .note-card-meta {
-  font-size: 0.8rem;
+  font-size: 0.78rem;
   color: var(--muted);
+  margin-left: auto;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .note-row-actions {
   display: inline-flex;
-  gap: 0.3rem;
+  gap: 0.25rem;
   align-items: center;
 }
 
 .note-children {
   display: flex;
   flex-direction: column;
-  gap: 0.2rem;
-  margin-left: 0.75rem;
+  gap: 0.18rem;
+  margin-left: 0.55rem;
   border-left: 1px dashed var(--note-connector-color);
-  padding-left: 0.75rem;
+  padding-left: 0.55rem;
 }
 
 .note-children[hidden] {
@@ -801,12 +810,12 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .note-toggle-spacer {
   color: transparent;
-  height: 1.9rem;
+  height: calc(var(--note-toggle-size) + 0.25rem);
 }
 
 .note-row-actions .icon-button {
-  width: 2rem;
-  height: 2rem;
+  width: 1.75rem;
+  height: 1.75rem;
   padding: 0;
   display: inline-flex;
   align-items: center;
@@ -860,17 +869,17 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
       "toggle card"
       "toggle actions";
     align-items: start;
-    padding-left: calc(var(--note-depth, 0) * 1rem);
-    gap: 0.5rem 0.55rem;
+    padding-left: calc(var(--note-depth, 0) * var(--note-indent-step));
+    gap: 0.35rem 0.4rem;
   }
 
   .note-row::before {
     content: "";
     position: absolute;
-    top: 0.6rem;
-    left: calc(var(--note-depth, 0) * 1rem + (var(--note-toggle-size) / 2));
+    top: 0.45rem;
+    left: calc(var(--note-depth, 0) * var(--note-indent-step) + (var(--note-toggle-size) / 2));
     width: 1px;
-    height: calc(var(--note-toggle-size) + 0.4rem);
+    height: calc(var(--note-toggle-size) + 0.25rem);
     background: var(--note-connector-color);
     opacity: 0.55;
     pointer-events: none;
@@ -899,8 +908,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
     display: flex;
     justify-content: flex-start;
     flex-wrap: wrap;
-    column-gap: 0.45rem;
-    row-gap: 0.35rem;
+    column-gap: 0.35rem;
+    row-gap: 0.3rem;
     width: 100%;
     margin-top: 0;
     padding: 0;
@@ -909,20 +918,20 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   .note-row-actions .icon-button {
     width: auto;
     height: auto;
-    min-width: 2.6rem;
-    min-height: 2.6rem;
+    min-width: 2.2rem;
+    min-height: 2.2rem;
   }
 
   .icon-button {
-    min-width: 2.6rem;
-    min-height: 2.6rem;
+    min-width: 2.2rem;
+    min-height: 2.2rem;
   }
 
   .note-children {
-    margin-left: calc(var(--note-toggle-size) + 0.35rem);
-    padding-left: 0.9rem;
+    margin-left: calc(var(--note-toggle-size) + 0.2rem);
+    padding-left: 0.65rem;
     border-left-width: 2px;
-    gap: 0.35rem;
+    gap: 0.28rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- reduce note list padding and indentation variables to create a denser note navigator layout
- restyle note cards into horizontal flex rows with subtle hover and active treatments plus right-aligned metadata
- tighten action button sizing and responsive spacing to keep compact presentation on mobile

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e11dbb36b8833382e98498d2b50eed