### PR TITLE
Add styling for root note cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -3221,6 +3221,9 @@ function bootstrapApp() {
     const noteCard = document.createElement("button");
     noteCard.type = "button";
     noteCard.className = "note-card";
+    if (level === 1) {
+      noteCard.classList.add("note-card--root");
+    }
     noteCard.dataset.noteId = note.id;
     noteCard.setAttribute("role", "treeitem");
     noteCard.setAttribute("aria-level", String(level));

--- a/styles.css
+++ b/styles.css
@@ -754,9 +754,21 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   transition: background 0.2s ease, border-color 0.2s ease;
 }
 
+.note-card--root {
+  background: rgba(60, 64, 67, 0.06);
+  color: #2d3748;
+  border-left-color: rgba(60, 64, 67, 0.3);
+}
+
 .note-card:hover {
   background: rgba(60, 64, 67, 0.08);
   border-left-color: rgba(26, 115, 232, 0.35);
+}
+
+.note-card--root:hover,
+.note-card--root:focus-visible {
+  background: rgba(60, 64, 67, 0.14);
+  color: #1f2937;
 }
 
 .note-card.active {
@@ -764,6 +776,18 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-left-color: var(--accent);
   background: rgba(26, 115, 232, 0.12);
   box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2);
+}
+
+.note-card--root:active {
+  background: rgba(26, 115, 232, 0.18);
+  color: #1f2937;
+}
+
+.note-card--root.active {
+  background: rgba(26, 115, 232, 0.18);
+  color: #0f172a;
+  border-color: rgba(26, 115, 232, 0.45);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.3);
 }
 
 .note-card-title {


### PR DESCRIPTION
## Summary
- add a dedicated CSS class to top-level note cards
- style root note cards with a subtle grey background and ensure hover, focus, and active states remain legible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e122d6cc308333b0f18d2ddabb1a17