### PR TITLE
Style root notes differently

### DIFF
--- a/app.js
+++ b/app.js
@@ -3191,7 +3191,7 @@ function bootstrapApp() {
 
     const noteCard = document.createElement("button");
     noteCard.type = "button";
-    noteCard.className = "note-card";
+    noteCard.classList.add("note-card");
     if (level === 1) {
       noteCard.classList.add("note-card--root");
     }

--- a/styles.css
+++ b/styles.css
@@ -739,9 +739,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .note-card--root {
-  background: rgba(60, 64, 67, 0.06);
-  color: #2d3748;
-  border-left-color: rgba(60, 64, 67, 0.3);
+  background: #f3f4f6;
+  color: #1f2937;
+  border-left-color: rgba(60, 64, 67, 0.28);
 }
 
 .note-card:hover {
@@ -751,8 +751,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .note-card--root:hover,
 .note-card--root:focus-visible {
-  background: rgba(60, 64, 67, 0.14);
-  color: #1f2937;
+  background: #e5e7eb;
+  color: #111827;
+  border-left-color: rgba(26, 115, 232, 0.35);
 }
 
 .note-card.active {
@@ -763,8 +764,8 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .note-card--root:active {
-  background: rgba(26, 115, 232, 0.18);
-  color: #1f2937;
+  background: rgba(26, 115, 232, 0.16);
+  color: #0f172a;
 }
 
 .note-card--root.active {


### PR DESCRIPTION
## Summary
- add a dedicated `note-card--root` class to root-level note buttons when rendering
- refresh the base, hover, focus, and active styles for root notes to use accessible muted grey tones

## Testing
- not run (static assets)


------
https://chatgpt.com/codex/tasks/task_e_68e126332410833398047f6a9e4b1d7a