### PR TITLE
Remove obsolete note card metadata display

### DIFF
--- a/app.js
+++ b/app.js
@@ -3244,11 +3244,6 @@ function bootstrapApp() {
     title.textContent = titleText;
     noteCard.appendChild(title);
 
-    const meta = document.createElement("span");
-    meta.className = "note-card-meta";
-    meta.textContent = formatRelativeDate(note.updatedAt);
-    noteCard.appendChild(meta);
-
     const actions = document.createElement("div");
     actions.className = "note-row-actions";
 
@@ -4553,12 +4548,6 @@ function bootstrapApp() {
       state.lastSavedAt = new Date();
       state.currentNote.updatedAt = state.lastSavedAt;
       updateLocalNoteCache(state.currentNoteId, { updatedAt: state.lastSavedAt });
-      const meta = ui.notesContainer.querySelector(
-        `.note-card[data-note-id="${state.currentNoteId}"] .note-card-meta`
-      );
-      if (meta) {
-        meta.textContent = formatRelativeDate(state.lastSavedAt);
-      }
       updateSaveStatus("saved", state.lastSavedAt);
     } catch (error) {
       state.hasUnsavedChanges = true;

--- a/styles.css
+++ b/styles.css
@@ -782,14 +782,6 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   min-width: 0;
 }
 
-.note-card-meta {
-  font-size: 0.78rem;
-  color: var(--muted);
-  margin-left: auto;
-  text-align: right;
-  white-space: nowrap;
-}
-
 .note-row-actions {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- stop rendering the note card metadata element and update logic in the note list
- drop the CSS selector for the removed metadata so titles can fill the available space

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e12ec9cbf48333b22a2cab16df577f