### PR TITLE
Adjust cloze priority filter initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -401,7 +401,7 @@ function bootstrapApp() {
     savedSelection: null,
     [CLOZE_MANUAL_REVEAL_SET_KEY]: new WeakSet(),
     share: createShareState(),
-    visibleClozePriorities: new Set(),
+    visibleClozePriorities: null,
     isClozeFilterMenuOpen: false,
   };
 
@@ -443,12 +443,7 @@ function bootstrapApp() {
 
   function ensureVisibleClozePriorities() {
     if (!(state.visibleClozePriorities instanceof Set)) {
-      state.visibleClozePriorities = new Set();
-    }
-    if (state.visibleClozePriorities.size === 0) {
-      CLOZE_PRIORITY_VALUES.forEach((value) => {
-        state.visibleClozePriorities.add(value);
-      });
+      state.visibleClozePriorities = new Set(CLOZE_PRIORITY_VALUES);
     }
     return state.visibleClozePriorities;
   }


### PR DESCRIPTION
## Summary
- initialize the cloze visibility state as null so it can represent an unconfigured filter
- only seed the visible cloze priorities set when creating it so empty selections stay empty

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e144ca852c8333924a6ab28c4c8ad7