### PR TITLE
Refine workspace theme surfaces

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -4,6 +4,11 @@
   --accent: #1a73e8;
   --accent-strong: #185abc;
   --border: #dadce0;
+  --bg-gradient-start: #f7f9ff;
+  --bg-gradient-end: #eef1f8;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-strong: rgba(255, 255, 255, 0.97);
+  --border-strong: rgba(15, 23, 42, 0.12);
   --muted: #5f6368;
   --card: #ffffff;
   --card-shadow: 0 1px 3px rgba(60, 64, 67, 0.2);
@@ -31,7 +36,9 @@ body {
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--bg);
+  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
+  background-attachment: fixed;
+  background-color: var(--bg-gradient-end);
   color: var(--fg);
   display: flex;
   flex-direction: column;
@@ -149,9 +156,11 @@ input[type="text"]:focus {
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.5rem 1.25rem 0.35rem;
-  background: #ffffff;
-  border-bottom: 1px solid var(--border);
-  box-shadow: 0 1px 2px rgba(60, 64, 67, 0.08);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   transition: top 0.25s ease, box-shadow 0.2s ease;
 }
 
@@ -488,9 +497,9 @@ body.header-collapsed #mobile-notes-btn {
   top: 0.75rem;
   left: 1.5rem;
   z-index: 50;
-  background: #ffffff;
-  border: 1px solid var(--border);
-  box-shadow: 0 2px 6px rgba(60, 64, 67, 0.18);
+  background: var(--surface-strong);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
   color: var(--fg);
 }
 
@@ -615,10 +624,13 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
 .workspace {
   display: grid;
-  grid-template-columns: minmax(240px, 26%) minmax(0, 1fr);
-  gap: 1.25rem;
-  align-items: stretch;
+  grid-template-columns: minmax(260px, 0.3fr) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
   transition: grid-template-columns 0.3s ease;
+  padding: 1.5rem 1.5rem 2.25rem;
+  margin: 0 auto;
+  width: min(1200px, 100%);
 }
 
 .workspace.sidebar-collapsed {
@@ -626,11 +638,11 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 }
 
 .note-list {
-  background: #ffffff;
-  border-radius: 0.85rem;
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 3px rgba(60, 64, 67, 0.12);
-  padding: 0.95rem 1rem;
+  background: var(--surface-strong);
+  border-radius: 1rem;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+  padding: 1.1rem 1.25rem;
   display: flex;
   flex-direction: column;
   min-height: 540px;
@@ -728,25 +740,26 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   gap: 0.5rem;
   flex: 1 1 auto;
   text-align: left;
-  background: transparent;
+  background: var(--surface);
   border: 1px solid transparent;
   border-left: 3px solid rgba(60, 64, 67, 0.16);
-  border-radius: 0.5rem;
-  padding: 0.45rem 0.65rem;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.75rem;
   color: inherit;
-  box-shadow: none;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.12);
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .note-card--root {
-  background: #f3f4f6;
+  background: var(--surface-strong);
   color: #1f2937;
   border-left-color: rgba(60, 64, 67, 0.28);
 }
 
 .note-card:hover {
-  background: rgba(60, 64, 67, 0.08);
+  background: var(--surface-strong);
   border-left-color: rgba(26, 115, 232, 0.35);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.18);
 }
 
 .note-card--root:hover,
@@ -760,7 +773,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   border-color: rgba(26, 115, 232, 0.35);
   border-left-color: var(--accent);
   background: rgba(26, 115, 232, 0.12);
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.2), 0 12px 28px rgba(15, 23, 42, 0.22);
 }
 
 .note-card--root:active {
@@ -772,7 +785,7 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   background: rgba(26, 115, 232, 0.18);
   color: #0f172a;
   border-color: rgba(26, 115, 232, 0.45);
-  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.3);
+  box-shadow: inset 0 0 0 1px rgba(26, 115, 232, 0.3), 0 14px 32px rgba(15, 23, 42, 0.24);
 }
 
 .note-card-title {
@@ -797,10 +810,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 .note-children {
   display: flex;
   flex-direction: column;
-  gap: 0.18rem;
-  margin-left: 0.55rem;
-  border-left: 1px dashed var(--note-connector-color);
-  padding-left: 0.55rem;
+  gap: 0.3rem;
+  margin-left: 0.75rem;
+  border-left: 1px solid var(--border-strong);
+  padding-left: 0.85rem;
 }
 
 .note-children[hidden] {
@@ -938,18 +951,18 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
 
   .note-children {
     margin-left: calc(var(--note-toggle-size) + 0.2rem);
-    padding-left: 0.65rem;
-    border-left-width: 2px;
-    gap: 0.28rem;
+    padding-left: 0.85rem;
+    border-left-width: 1px;
+    gap: 0.3rem;
   }
 }
 
 .editor-area {
-  background: transparent;
-  border-radius: 0;
-  border: none;
-  box-shadow: none;
-  padding: 1.25rem 1.5rem 2rem;
+  background: var(--surface-strong);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.14);
+  padding: 1.75rem 2rem 2.5rem;
   min-height: 540px;
   display: flex;
   flex-direction: column;
@@ -998,10 +1011,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   padding: 0.75rem 0.85rem;
   margin: 0 auto;
   width: 100%;
-  background: var(--editor-toolbar-surface);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 0.85rem;
-  box-shadow: 0 8px 24px rgba(15, 23, 42, 0.08);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 1rem;
+  box-shadow: 0 16px 36px rgba(15, 23, 42, 0.16);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   transition: box-shadow 0.2s ease, border-color 0.2s ease;
@@ -1288,10 +1301,10 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   position: absolute;
   top: calc(100% + 0.35rem);
   right: 0;
-  background: var(--editor-toolbar-surface);
-  border: 1px solid rgba(15, 23, 42, 0.12);
-  border-radius: 0.65rem;
-  box-shadow: 0 10px 26px rgba(15, 23, 42, 0.18);
+  background: var(--surface);
+  border: 1px solid var(--border-strong);
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
   padding: 0.4rem;
   min-width: 200px;
   display: none;
@@ -2593,7 +2606,9 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .workspace {
-    gap: 1.25rem;
+    gap: 1.35rem;
+    padding: 1.35rem 1.25rem 2rem;
+    width: min(100%, 1080px);
   }
 }
 
@@ -2621,7 +2636,9 @@ body.notes-drawer-open .drawer-overlay {
 
   .workspace {
     grid-template-columns: minmax(0, 1fr);
-    gap: 1rem;
+    gap: 1.25rem;
+    padding: 1.25rem 1.1rem calc(2.5rem + env(safe-area-inset-bottom, 0));
+    width: 100%;
   }
 
   .workspace.sidebar-collapsed {
@@ -2635,12 +2652,12 @@ body.notes-drawer-open .drawer-overlay {
     max-width: 360px;
     min-height: 100vh;
     max-height: none;
-    border-radius: 0 1rem 1rem 0;
+    border-radius: 0 1.25rem 1.25rem 0;
     transform: translateX(-110%);
     opacity: 1;
-    padding: 1.5rem 1.2rem 2rem;
+    padding: 1.6rem 1.3rem 2.25rem;
     z-index: 130;
-    box-shadow: 0 16px 32px rgba(60, 64, 67, 0.24);
+    box-shadow: 0 24px 42px rgba(15, 23, 42, 0.28);
   }
 
   .note-list-actions {
@@ -2666,15 +2683,15 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-area {
-    padding: 1rem 1rem calc(2.75rem + env(safe-area-inset-bottom, 0));
+    padding: 1.4rem 1.25rem calc(2.75rem + env(safe-area-inset-bottom, 0));
     min-height: calc(100vh - var(--header-height) - 1.5rem);
   }
 
   .editor-toolbar {
-    padding: 0.65rem 0.75rem;
+    padding: 0.7rem 0.75rem;
     gap: 0.45rem;
-    border-radius: 0.75rem;
-    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.12);
+    border-radius: 0.9rem;
+    box-shadow: 0 14px 32px rgba(15, 23, 42, 0.18);
   }
 
   .toolbar-row {
@@ -2811,7 +2828,7 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-area {
-    padding: 0.85rem 0.75rem calc(2.5rem + env(safe-area-inset-bottom, 0));
+    padding: 1rem 0.85rem calc(2.5rem + env(safe-area-inset-bottom, 0));
     min-height: calc(100vh - var(--header-height));
   }
 
@@ -2822,13 +2839,13 @@ body.notes-drawer-open .drawer-overlay {
   }
 
   .editor-toolbar {
-    padding: 0.55rem 0.6rem;
+    padding: 0.6rem 0.65rem;
     gap: 0.35rem;
     border-radius: 0.65rem;
     align-self: stretch;
     flex-shrink: 0;
-    border: 1px solid rgba(15, 23, 42, 0.12);
-    box-shadow: 0 10px 28px rgba(15, 23, 42, 0.14);
+    border: 1px solid var(--border-strong);
+    box-shadow: 0 12px 28px rgba(15, 23, 42, 0.18);
     margin: 0;
   }
 
@@ -2837,7 +2854,7 @@ body.notes-drawer-open .drawer-overlay {
     flex: 0 0 auto;
     margin-left: auto;
     background: transparent;
-    border: 1px solid rgba(15, 23, 42, 0.12);
+    border: 1px solid var(--border-strong);
     color: var(--muted);
     min-width: 2.1rem;
     min-height: 2.1rem;
@@ -2978,7 +2995,7 @@ body.notes-drawer-open .drawer-overlay {
 }
 
 body.revision-mode {
-  background: #edf1f5;
+  background: linear-gradient(135deg, var(--bg-gradient-start), var(--bg-gradient-end));
 }
 
 body.revision-mode .workspace {


### PR DESCRIPTION
## Summary
- introduce gradient-based background palette with reusable surface variables
- refresh workspace panels, note cards, and toolbar styling to use the new surfaces and subtle shadows
- adjust responsive spacing and overlays so the updated look remains cohesive on smaller screens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e145ef2c108333a6f776c94b16079e