### PR TITLE
Ensure cloze insertion uses token-scoped pending selector

### DIFF
--- a/app.js
+++ b/app.js
@@ -5449,10 +5449,14 @@ function bootstrapApp() {
       }
     }
 
+    const pendingToken = `cloze-${Date.now()}-${Math.random()
+      .toString(36)
+      .slice(2)}`;
+
     const htmlToInsert = nodesToInsert
       .map(({ node, block }) => {
         const clonedNode = node.cloneNode(true);
-        clonedNode.setAttribute("data-cloze-pending", "1");
+        clonedNode.setAttribute("data-cloze-pending", pendingToken);
         if (block) {
           clonedNode.setAttribute("data-cloze-pending-block", "1");
         }
@@ -5470,7 +5474,9 @@ function bootstrapApp() {
     document.execCommand("insertHTML", false, htmlToInsert);
 
     const insertedClozeEntries = Array.from(
-      ui.noteEditor.querySelectorAll("[data-cloze-pending]")
+      ui.noteEditor.querySelectorAll(
+        `[data-cloze-pending="${pendingToken}"]`
+      )
     ).map((node) => {
       const block = node.getAttribute("data-cloze-pending-block") === "1";
       node.removeAttribute("data-cloze-pending");


### PR DESCRIPTION
## Summary
- scope the temporary pending attribute used when creating clozes from the selection to a unique token
- ensure only the freshly inserted cloze nodes are reinitialized after the execCommand HTML insertion

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e14f2431f483338a85e244f6daedde