### PR TITLE
Persist preferred cloze priority on primary button

### DIFF
--- a/app.js
+++ b/app.js
@@ -6283,8 +6283,10 @@ function bootstrapApp() {
           });
           setClozeDropdown(false, { focusTarget: "toggle" });
         } else {
+          const preferredPriority = getPreferredClozePriority();
+          persistPreferredClozePriority(preferredPriority);
           runWithPreservedSelection(() => {
-            createClozeFromSelection(getPreferredClozePriority());
+            createClozeFromSelection(preferredPriority);
           });
         }
       } else if (action === "insertDropdown") {


### PR DESCRIPTION
## Summary
- reuse the stored preferred cloze priority when invoking the main toolbar button
- persist the preferred priority to localStorage when the primary button is used

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15103e0488333905582be0a55bf7e