### PR TITLE
Add linked cloze group support

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,16 @@
               <button
                 type="button"
                 class="toolbar-button"
+                data-action="createLinkedCloze"
+                data-priority="medium"
+                title="Créer un texte à trous lié (priorité moyenne)"
+              >
+                <span class="icon" aria-hidden="true">⧉↔</span>
+                <span class="sr-only">Créer un texte à trous lié (priorité moyenne)</span>
+              </button>
+              <button
+                type="button"
+                class="toolbar-button"
                 data-action="startIteration"
                 title="Lancer une itération"
               >


### PR DESCRIPTION
## Summary
- track the last created cloze and allocate reusable data-link-group identifiers
- link grouped clozes when requested and reveal or filter them together in the editor
- expose a toolbar control for creating linked clozes and persist the configured priority

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e15315da1c83339cce39a36d52a5f2