### PR TITLE
Adjust workspace layout width handling

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -629,8 +629,9 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   align-items: start;
   transition: grid-template-columns 0.3s ease;
   padding: 1.5rem 1.5rem 2.25rem;
-  margin: 0 auto;
-  width: min(1200px, 100%);
+  margin: 0;
+  width: 100%;
+  max-width: 1200px;
 }
 
 .workspace.sidebar-collapsed {


### PR DESCRIPTION
## Summary
- remove auto-centering margin from the workspace container
- ensure the workspace expands to the available width while retaining a 1200px maximum

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16e072a9c8333be2a6c37b267bf81