### PR TITLE
Déplacer la création de texte lié dans le menu de priorité

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,18 +259,28 @@
                     <span class="toolbar-dropdown-item-icon" aria-hidden="true"></span>
                     <span>Priorité basse</span>
                   </button>
+                  <button
+                    type="button"
+                    class="toolbar-dropdown-item"
+                    data-action="createLinkedCloze"
+                    data-priority="medium"
+                    role="menuitem"
+                    title="Créer un texte à trous lié (priorité moyenne)"
+                  >
+                    <span class="toolbar-dropdown-item-icon" aria-hidden="true">⧉↔</span>
+                    <span
+                      class="toolbar-dropdown-item-label"
+                      data-linked-cloze-visible-label
+                      aria-hidden="true"
+                    >
+                      Créer un texte à trous lié (priorité moyenne)
+                    </span>
+                    <span class="sr-only" data-linked-cloze-sr-label>
+                      Créer un texte à trous lié (priorité moyenne)
+                    </span>
+                  </button>
                 </div>
               </div>
-              <button
-                type="button"
-                class="toolbar-button"
-                data-action="createLinkedCloze"
-                data-priority="medium"
-                title="Créer un texte à trous lié (priorité moyenne)"
-              >
-                <span class="icon" aria-hidden="true">⧉↔</span>
-                <span class="sr-only">Créer un texte à trous lié (priorité moyenne)</span>
-              </button>
               <button
                 type="button"
                 class="toolbar-button"


### PR DESCRIPTION
## Summary
- déplacer l’action « texte à trous lié » à l’intérieur du menu de priorité en conservant l’accessibilité et l’icône
- adapter la logique JavaScript pour cibler le nouvel élément du menu, fermer correctement le menu et propager la priorité
- mettre à jour la synchronisation de priorité pour toutes les entrées « texte lié » et leurs libellés visibles/assistifs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2344ff2008333b44d46f3fb270662