### PR TITLE
Remove linked cloze priority-specific UI text

### DIFF
--- a/app.js
+++ b/app.js
@@ -1903,13 +1903,6 @@ function bootstrapApp() {
     return `Créer un texte à trous (priorité ${suffix})`;
   }
 
-  function formatLinkedClozePriorityTitle(priority) {
-    const normalized = normalizeClozePriorityValue(priority);
-    const suffix =
-      CLOZE_PRIORITY_LABELS[normalized] || CLOZE_PRIORITY_LABELS[CLOZE_DEFAULT_PRIORITY];
-    return `Créer un texte à trous lié (priorité ${suffix})`;
-  }
-
   function updatePreferredClozePriorityUI(priority) {
     const normalized = normalizeClozePriorityValue(priority);
     if (ui.clozeDropdownMain) {
@@ -1929,22 +1922,6 @@ function bootstrapApp() {
     if (linkedClozeButtons.length > 0) {
       ui.linkedClozeButton = linkedClozeButtons[0];
     }
-
-    linkedClozeButtons.forEach((linkedButton) => {
-      linkedButton.dataset.priority = normalized;
-      const linkedTitle = formatLinkedClozePriorityTitle(normalized);
-      linkedButton.title = linkedTitle;
-      const linkedVisibleLabel = linkedButton.querySelector(
-        "[data-linked-cloze-visible-label]"
-      );
-      if (linkedVisibleLabel) {
-        linkedVisibleLabel.textContent = linkedTitle;
-      }
-      const linkedSrLabel = linkedButton.querySelector(".sr-only");
-      if (linkedSrLabel) {
-        linkedSrLabel.textContent = linkedTitle;
-      }
-    });
 
     if (ui.clozeDropdownMenu) {
       const items = ui.clozeDropdownMenu.querySelectorAll('button[data-action="createCloze"]');
@@ -6580,8 +6557,7 @@ function bootstrapApp() {
         handledBySelectionHelper = true;
         const insideDropdownMenu = Boolean(button.closest(".toolbar-dropdown-menu"));
         if (insideDropdownMenu) {
-          const selectedPriority = normalizeClozePriorityValue(button.dataset.priority);
-          const appliedPriority = setPreferredClozePriority(selectedPriority);
+          const appliedPriority = getPreferredClozePriority();
           runWithPreservedSelection(() => {
             createClozeFromSelection({
               priority: appliedPriority,

--- a/index.html
+++ b/index.html
@@ -263,9 +263,8 @@
                     type="button"
                     class="toolbar-dropdown-item"
                     data-action="createLinkedCloze"
-                    data-priority="medium"
                     role="menuitem"
-                    title="Créer un texte à trous lié (priorité moyenne)"
+                    title="Créer un texte à trous lié"
                   >
                     <span class="toolbar-dropdown-item-icon" aria-hidden="true">⧉↔</span>
                     <span
@@ -273,10 +272,10 @@
                       data-linked-cloze-visible-label
                       aria-hidden="true"
                     >
-                      Créer un texte à trous lié (priorité moyenne)
+                      Créer un texte à trous lié
                     </span>
                     <span class="sr-only" data-linked-cloze-sr-label>
-                      Créer un texte à trous lié (priorité moyenne)
+                      Créer un texte à trous lié
                     </span>
                   </button>
                 </div>


### PR DESCRIPTION
## Summary
- simplify the linked cloze dropdown menu item to avoid mentioning priorities
- remove the dynamic priority title/label updates for linked cloze buttons while keeping caching
- rely on the existing preferred priority when creating linked cloze entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24264a1d88333b0bca67ee68c13ef