### PR TITLE
Extend font size options below 10pt

### DIFF
--- a/app.js
+++ b/app.js
@@ -100,8 +100,8 @@ function bootstrapApp() {
   const HIGHLIGHT_COLOR = "#fde68a";
   const DEFAULT_TEXT_COLOR = "#1f2937";
   const DEFAULT_FONT_FAMILY = "Arial";
-  const FONT_SIZE_STEPS = [10, 11, 12, 14, 18, 24, 32];
-  const DEFAULT_FONT_SIZE_INDEX = 1;
+  const FONT_SIZE_STEPS = [8, 9, 10, 11, 12, 14, 18, 24, 32];
+  const DEFAULT_FONT_SIZE_INDEX = 3;
   const TEXT_COLOR_PRESETS = [
     { value: "#0f172a", label: "Bleu nuit" },
     { value: "#1f2937", label: "Gris anthracite" },


### PR DESCRIPTION
## Summary
- extend the font size presets to include 8 pt and 9 pt
- update the default font size index so the default remains 11 pt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e268decd908333b07f95ce8a162460