### PR TITLE
Fix cloze creation for partial list selections

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,7 @@ import {
 import { firebaseConfig } from "./firebase-config.js";
 import { signIn, signUp, resetPassword } from "./auth.js";
 import { shareNoteByEmail } from "./sharing.js";
+import { prepareNodesForClozeInsertion } from "./cloze-utils.mjs";
 
 const REQUIRED_FIREBASE_CONFIG_KEYS = [
   "apiKey",
@@ -5622,8 +5623,15 @@ function bootstrapApp() {
     const containsBlockNodes = fragmentContainsBlockNodes(fragment);
     const wrapperTagName = containsBlockNodes ? "div" : "span";
     const wrapper = document.createElement(wrapperTagName);
-    while (fragment.firstChild) {
-      wrapper.appendChild(fragment.firstChild);
+    const nodesToInsert = prepareNodesForClozeInsertion(fragment, range);
+    if (nodesToInsert.length) {
+      nodesToInsert.forEach((node) => {
+        wrapper.appendChild(node);
+      });
+    } else {
+      while (fragment.firstChild) {
+        wrapper.appendChild(fragment.firstChild);
+      }
     }
 
     if (!wrapper.hasChildNodes()) {

--- a/cloze-utils.mjs
+++ b/cloze-utils.mjs
@@ -1,0 +1,84 @@
+const LIST_ITEM_TAGS = new Set(["LI", "DT", "DD"]);
+const LIST_CONTAINER_TAGS = new Set(["UL", "OL", "DL"]);
+
+function collectListItemsInRange(range) {
+  if (!range || !range.commonAncestorContainer) {
+    return [];
+  }
+  const items = [];
+  const walker = document.createTreeWalker(
+    range.commonAncestorContainer,
+    NodeFilter.SHOW_ELEMENT,
+    {
+      acceptNode(node) {
+        if (!node || !LIST_ITEM_TAGS.has(node.tagName)) {
+          return NodeFilter.FILTER_SKIP;
+        }
+        try {
+          return range.intersectsNode(node)
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_SKIP;
+        } catch (error) {
+          return NodeFilter.FILTER_SKIP;
+        }
+      },
+    },
+    false
+  );
+  while (walker.nextNode()) {
+    items.push(walker.currentNode);
+  }
+  return items;
+}
+
+export function prepareNodesForClozeInsertion(fragment, range) {
+  if (!fragment) {
+    return [];
+  }
+  const nodes = Array.from(fragment.childNodes || []);
+  if (!nodes.length) {
+    return nodes;
+  }
+
+  const listItems = collectListItemsInRange(range);
+  const listGroupSources = new WeakMap();
+  const normalizedNodes = [];
+  let listItemIndex = 0;
+
+  nodes.forEach((node) => {
+    if (
+      node &&
+      node.nodeType === Node.ELEMENT_NODE &&
+      LIST_ITEM_TAGS.has(node.tagName)
+    ) {
+      const originalListItem = listItems[listItemIndex] || null;
+      if (originalListItem) {
+        listItemIndex += 1;
+        const originalListContainer = originalListItem.parentElement;
+        if (
+          originalListContainer &&
+          LIST_CONTAINER_TAGS.has(originalListContainer.tagName)
+        ) {
+          let lastNode =
+            normalizedNodes.length > 0
+              ? normalizedNodes[normalizedNodes.length - 1]
+              : null;
+          if (listGroupSources.get(lastNode) !== originalListContainer) {
+            const clonedListContainer = originalListContainer.cloneNode(false);
+            listGroupSources.set(clonedListContainer, originalListContainer);
+            normalizedNodes.push(clonedListContainer);
+            lastNode = clonedListContainer;
+          }
+          if (lastNode) {
+            lastNode.appendChild(node);
+            return;
+          }
+        }
+      }
+    }
+
+    normalizedNodes.push(node);
+  });
+
+  return normalizedNodes;
+}

--- a/tests/createClozePartialList.test.js
+++ b/tests/createClozePartialList.test.js
@@ -1,0 +1,99 @@
+const { JSDOM } = require('jsdom');
+
+(async () => {
+  const { prepareNodesForClozeInsertion } = await import('../cloze-utils.mjs');
+
+  const dom = new JSDOM(
+    '<!DOCTYPE html><body><div id="editor" contenteditable="true"></div></body>',
+    { pretendToBeVisual: true }
+  );
+
+  const { window } = dom;
+  const { document } = window;
+
+  global.window = window;
+  global.document = document;
+  global.Node = window.Node;
+  global.NodeFilter = window.NodeFilter;
+
+  const editor = document.getElementById('editor');
+  editor.innerHTML =
+    '<p>Avant</p><ul><li>Alpha</li><li>Bravo</li><li>Charlie</li></ul><p>Après</p>';
+
+  const list = editor.querySelector('ul');
+  const secondItem = list.children[1];
+  const thirdItem = list.children[2];
+
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  const range = document.createRange();
+  range.setStartBefore(secondItem);
+  range.setEndAfter(thirdItem);
+  selection.addRange(range);
+
+  const fragment = range.cloneContents();
+  const nodesToInsert = prepareNodesForClozeInsertion(fragment, range);
+
+  const wrapper = document.createElement('div');
+  nodesToInsert.forEach((node) => {
+    wrapper.appendChild(node);
+  });
+
+  if (!wrapper.firstElementChild || wrapper.childElementCount !== 1) {
+    console.error('Expected a single cloned list container in the wrapper.');
+    process.exit(1);
+  }
+
+  const pendingToken = 'test-token';
+  wrapper.setAttribute('data-cloze-pending', pendingToken);
+  wrapper.setAttribute('data-cloze-pending-block', '1');
+
+  const container = document.createElement('div');
+  container.appendChild(wrapper);
+  const htmlToInsert = container.innerHTML;
+
+  range.deleteContents();
+  const tempContainer = document.createElement('div');
+  tempContainer.innerHTML = htmlToInsert;
+  const insertedWrapper = tempContainer.firstElementChild;
+  range.insertNode(insertedWrapper);
+
+  const insertedCloze = editor.querySelector(
+    `[data-cloze-pending="${pendingToken}"]`
+  );
+
+  if (!insertedCloze) {
+    console.error('Inserted cloze wrapper not found.');
+    process.exit(1);
+  }
+
+  const initializeClozeElement = (cloze, { block = false } = {}) => {
+    cloze.classList.add('cloze');
+    if (block) {
+      cloze.classList.add('cloze--block');
+    }
+    return cloze;
+  };
+
+  initializeClozeElement(insertedCloze, { block: true });
+
+  const clozes = editor.querySelectorAll('.cloze');
+  if (clozes.length !== 1) {
+    console.error(`Expected a single cloze element, received ${clozes.length}.`);
+    process.exit(1);
+  }
+
+  const clonedList = clozes[0].firstElementChild;
+  if (!clonedList || clonedList.tagName !== 'UL') {
+    console.error('Expected the cloze to wrap a UL element.');
+    process.exit(1);
+  }
+
+  const clonedItems = Array.from(clonedList.children).map((node) => node.textContent);
+  if (clonedItems.join(',') !== 'Bravo,Charlie') {
+    console.error('Unexpected list items within the cloze:', clonedItems);
+    process.exit(1);
+  }
+
+  console.log('Partial list selection produces a single cloze element.');
+})();


### PR DESCRIPTION
## Summary
- group selected list items by their parent list before inserting cloze fragments
- factor node normalization into a reusable helper used by the editor
- add a regression test ensuring partial list selections produce a single cloze element

## Testing
- node tests/createClozePartialList.test.js
- node tests/runWithPreservedSelection.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e26f2c74a48333b36ecf7dcbe92368