### PR TITLE
feat: add course dashboard experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,13 +20,21 @@
           <button
             type="button"
             id="mobile-notes-btn"
-            class="header-icon-button"
+            class="header-icon-button workspace-only"
             aria-label="Afficher les fiches"
             aria-pressed="false"
             aria-expanded="true"
           >
             ☰
             <span class="sr-only">Afficher les fiches</span>
+          </button>
+          <button
+            type="button"
+            id="back-to-courses-btn"
+            class="ghost header-back-button workspace-only"
+            aria-label="Revenir à la liste des cours"
+          >
+            ← Tous les cours
           </button>
           <div class="brand-text">
             <h1>Apprentissage actif</h1>
@@ -36,7 +44,7 @@
             <button
               type="button"
               id="revision-mode-toggle"
-              class="header-mode-toggle ghost"
+              class="header-mode-toggle ghost workspace-only"
               aria-pressed="false"
               aria-label="Activer le mode révision"
             >
@@ -77,7 +85,7 @@
         <button
           type="button"
           id="revision-iteration-btn"
-          class="header-iteration-btn"
+          class="header-iteration-btn workspace-only"
           aria-label="Lancer une nouvelle itération"
         >
           Nouvelle itération
@@ -341,6 +349,18 @@
         </div>
       </section>
 
+      <section id="course-dashboard" class="view hidden">
+        <div class="courses-page" aria-labelledby="courses-title">
+          <header class="courses-page__header">
+            <div>
+              <h2 id="courses-title">Vos cours</h2>
+              <p class="muted">Choisissez un cours pour afficher vos fiches ou créez-en un nouveau.</p>
+            </div>
+          </header>
+          <div id="course-grid" class="course-grid" role="list"></div>
+        </div>
+      </section>
+
       <section id="workspace" class="view hidden">
         <div class="workspace">
           <aside class="note-list" aria-label="Mes fiches">
@@ -397,6 +417,41 @@
         <div id="drawer-overlay" class="drawer-overlay" hidden></div>
       </section>
     </main>
+
+    <div
+      id="course-form-overlay"
+      class="course-form-overlay hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="course-form-title"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <div class="course-form-card" role="document">
+        <header class="course-form-card__header">
+          <h2 id="course-form-title">Nouveau cours</h2>
+          <button type="button" id="course-form-close" class="header-icon-button" aria-label="Fermer la fenêtre de création de cours">✕</button>
+        </header>
+        <form id="course-form" class="course-form" novalidate>
+          <label for="course-name">Nom du cours</label>
+          <input id="course-name" name="name" type="text" placeholder="Ex. Mathématiques" autocomplete="off" required maxlength="120" />
+          <label for="course-image">Image représentative (optionnel)</label>
+          <input
+            id="course-image"
+            name="image"
+            type="url"
+            inputmode="url"
+            placeholder="https://..."
+            autocomplete="off"
+          />
+          <p id="course-form-error" class="form-message error hidden" role="alert"></p>
+          <div class="course-form__actions">
+            <button type="button" id="course-form-cancel" class="ghost">Annuler</button>
+            <button type="submit" id="course-form-submit">Créer le cours</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <div id="share-dialog-backdrop" class="share-dialog-backdrop hidden" aria-hidden="true"></div>
     <section

--- a/styles.css
+++ b/styles.css
@@ -37,6 +37,18 @@ body {
   flex-direction: column;
 }
 
+body:not([data-view="workspace"]) .workspace-only {
+  display: none !important;
+}
+
+body[data-view="workspace"] .course-only {
+  display: none !important;
+}
+
+body.course-form-open {
+  overflow: hidden;
+}
+
 body.keyboard-visible {
   min-height: 100%;
   height: auto;
@@ -155,12 +167,37 @@ input[type="text"]:focus {
   transition: top 0.25s ease, box-shadow 0.2s ease;
 }
 
+.header-toolbar,
+.header-top-controls,
+#revision-iteration-btn {
+  transition: opacity 0.2s ease, visibility 0.2s ease;
+}
+
+body:not([data-view="workspace"]) .header-toolbar {
+  display: none;
+}
+
 .header-top {
   display: flex;
   align-items: center;
   gap: 0.75rem;
   flex-wrap: wrap;
   align-content: center;
+}
+
+.header-back-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  line-height: 1.1;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.header-back-button:hover {
+  background: rgba(60, 64, 67, 0.12);
 }
 
 .header-toolbar {
@@ -451,6 +488,203 @@ body.header-collapsed #mobile-notes-btn[aria-pressed="true"] {
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.courses-page {
+  width: min(1100px, 100%);
+  margin: 0 auto;
+  padding: 4.5rem 1.5rem 3.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.courses-page__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.course-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: stretch;
+}
+
+.course-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.9rem;
+  padding: 1rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(60, 64, 67, 0.18);
+  background: var(--card);
+  box-shadow: var(--card-shadow);
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.course-card:hover {
+  background: var(--card);
+  transform: translateY(-2px);
+  border-color: rgba(26, 115, 232, 0.32);
+  box-shadow: 0 12px 28px rgba(32, 33, 36, 0.18);
+}
+
+.course-card:focus-visible {
+  outline: 3px solid rgba(26, 115, 232, 0.35);
+  outline-offset: 2px;
+}
+
+.course-card-cover {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 1rem;
+  overflow: hidden;
+  min-height: 140px;
+  isolation: isolate;
+  background: linear-gradient(135deg, rgba(26, 115, 232, 0.15), rgba(26, 115, 232, 0.5));
+  color: rgba(255, 255, 255, 0.92);
+  font-size: 2.2rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.course-card-cover--with-image {
+  background: transparent;
+}
+
+.course-card-cover--with-image::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(32, 33, 36, 0.12), rgba(32, 33, 36, 0.35));
+  pointer-events: none;
+}
+
+.course-card-cover__image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.course-card-cover__initial {
+  position: relative;
+  z-index: 1;
+}
+
+.course-card-cover--with-image .course-card-cover__initial {
+  opacity: 0;
+}
+
+.course-card-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.course-card-meta {
+  font-size: 0.9rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.course-card--new {
+  border: 1px dashed rgba(26, 115, 232, 0.4);
+  background: rgba(26, 115, 232, 0.05);
+  color: var(--accent-strong);
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.course-card--new:hover {
+  border-color: rgba(26, 115, 232, 0.6);
+  background: rgba(26, 115, 232, 0.12);
+}
+
+.course-card--new .course-card-cover {
+  width: 72px;
+  height: 72px;
+  border-radius: 999px;
+  font-size: 2.4rem;
+  background: rgba(26, 115, 232, 0.12);
+  margin-bottom: 0.25rem;
+}
+
+.course-card--new .course-card-title {
+  font-size: 1rem;
+}
+
+.course-card--active {
+  border-color: rgba(26, 115, 232, 0.65);
+  box-shadow: 0 14px 32px rgba(26, 115, 232, 0.25);
+}
+
+.course-grid__empty {
+  grid-column: 1 / -1;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.course-form-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgba(32, 33, 36, 0.55);
+  z-index: 160;
+}
+
+.course-form-card {
+  width: min(440px, 100%);
+  background: var(--card);
+  border-radius: 1.5rem;
+  box-shadow: 0 18px 48px rgba(32, 33, 36, 0.35);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.course-form-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.course-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.course-form input[type="text"],
+.course-form input[type="url"] {
+  width: 100%;
+}
+
+.course-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
 }
 
 .auth-tabs {
@@ -1959,6 +2193,19 @@ body.share-dialog-open {
   .share-dialog__footer {
     padding: 1rem 1.25rem 1.25rem;
   }
+
+  .courses-page {
+    padding: 3.5rem 1.25rem 2.75rem;
+  }
+
+  .course-card {
+    padding: 0.9rem;
+  }
+
+  .course-card-cover {
+    min-height: 120px;
+    font-size: 2rem;
+  }
 }
 
 .drawer-overlay {
@@ -2179,9 +2426,21 @@ body.notes-drawer-open .drawer-overlay {
 
   .brand {
     display: grid;
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto auto 1fr auto;
     align-items: center;
     column-gap: 0.5rem;
+  }
+
+  .brand-text {
+    grid-column: 1 / -1;
+  }
+
+  #mobile-notes-btn {
+    grid-column: 1;
+  }
+
+  #back-to-courses-btn {
+    grid-column: 2;
   }
 
   .header-top-controls {


### PR DESCRIPTION
## Summary
- add a course dashboard home view with card layout and course creation dialog
- wire Firestore data to filter notes by course, track unassigned notes, and update the header
- refresh styles for the new dashboard, responsive layout, and modal overlay

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ef8918a580833396ec4458445f2866